### PR TITLE
Add missing dependencies in requirements_dev

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,3 +16,5 @@ deepdiff
 insipid-sphinx-theme
 tox-wheel
 autodocsumm
+netCDF4
+beautifulsoup4


### PR DESCRIPTION
Required for read the docs to build via Sphinx.

Linked to #3 