### PR TITLE
Separation of multiple units

### DIFF
--- a/sofar/sofar.py
+++ b/sofar/sofar.py
@@ -1,4 +1,5 @@
 import os
+import re
 import glob
 import json
 import requests
@@ -927,13 +928,19 @@ class Sofa():
 
             # in case test is a string it might be a unit and unit aliases
             # according to the SOFA standard must be checked
-            units = test.split(", ") if isinstance(test, str) else []
-            ref = ref.split(", ") if isinstance(ref, str) else ref
 
+            # Following the SOFA standard AES69-2020, units may be separated by
+            # `, ` (comma and space), `,` (comma only), and ` ` (space only).
+            # (regexp ', ?' matches ', ' and ',')
+            ref = re.split(', ?| ', ref) if isinstance(ref, str) else ref
+            units = re.split(', ?| ', test) if isinstance(test, str) else []
+
+            # check if number of units agree
             if not units or len(ref) != len(units):
                 value_valid = False
                 return value_valid
 
+            # check if units are valid
             for unit, unit_ref in zip(units, ref):
                 if unit != unit_ref and (unit not in unit_aliases
                                          or unit_aliases[unit] != unit_ref):

--- a/tests/test_sofar.py
+++ b/tests/test_sofar.py
@@ -504,7 +504,7 @@ def test_verify_value():
                     "degrees": "degree"}
 
     # Simple pass: no restriction on value
-    assert sf.Sofa._verify_value("meter", None, unit_aliases)
+    assert sf.Sofa._verify_value("goofy", None, unit_aliases)
 
     # simple pass: single unit
     assert sf.Sofa._verify_value("meter", "metre", unit_aliases)
@@ -513,8 +513,12 @@ def test_verify_value():
     assert sf.Sofa._verify_value("degrees, degrees, meter",
                                  "degree, degree, metre", unit_aliases)
 
+    # complex pass: list of units with other separators allowed by AES69
+    assert sf.Sofa._verify_value("degrees,degrees meter",
+                                 "degree, degree, metre", unit_aliases)
+
     # simple fail: single unit
-    assert not sf.Sofa._verify_value("centimetre", "metre", unit_aliases)
+    assert not sf.Sofa._verify_value("centimeter", "metre", unit_aliases)
 
     # complex fail: list of units
     assert not sf.Sofa._verify_value("rad, rad, metre",


### PR DESCRIPTION
AES 69 says: "In case of multiple units, writing applications shall separate the units by a comma and a space [...]. Reading applications should accept unit lists separated by a comma symbol [...] or a space symbol."

sofar now follows this recommendation and accepts units separated by (comma space), (comma), and (space).