### PR TITLE
Test if sphinx build is succesful on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,32 @@ jobs:
           name: Flake8
           command: flake8 sofar
 
+  test_documentation_build:
+    parameters:
+      version:
+        description: "version tag"
+        default: "latest"
+        type: string
+    executor:
+      name: python-docker
+      version: <<parameters.version>>
+
+    steps:
+      - checkout
+      - run:
+          name: Install System Dependencies
+          command: sudo apt-get update && sudo apt-get install -y texlive-latex-extra dvipng
+      - python/install-packages:
+          pkg-manager: pip
+          # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.
+          pip-dependency-file: requirements_dev.txt
+      - run:
+          name: Sphinx
+          command: |
+            pip install -e .
+            cd docs/
+            make html SPHINXOPTS="-W"
+
   test_pypi_publish:
     parameters:
       version:
@@ -109,6 +135,14 @@ workflows:
           requires:
             - build_and_test
 
+      - test_documentation_build:
+          matrix:
+            parameters:
+              version:
+                - "3.9"
+          requires:
+            - build_and_test
+
   test_and_publish:
     # Test and publish on new git version tags
     # This requires its own workflow to successfully trigger the test and build
@@ -142,6 +176,20 @@ workflows:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*$/
 
+      - test_documentation_build:
+          matrix:
+            parameters:
+              version:
+                - "3.9"
+          requires:
+            - build_and_test
+          filters:
+            branches:
+              ignore: /.*/
+            # only act on version tags
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*$/
+
       - test_pypi_publish:
           matrix:
             parameters:
@@ -150,6 +198,7 @@ workflows:
           requires:
             - build_and_test
             - flake
+            - test_documentation_build
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
### Changes proposed in this pull request:

Test building the Sphinx documentation

This will not check if the generated HTML documents are valid nor will it validate against a reference.
It will merely fail on:
- broken example code
- Sphinx build errors

Building the docs on CircleCI required adding about 400 megabytes of latex packages.
It's probably better to add them to the Docker container in the future. This probably requires a custom one though.