### PR TITLE
Fix import error occuring in autodoc

### DIFF
--- a/docs/sofar.rst
+++ b/docs/sofar.rst
@@ -6,7 +6,7 @@ sofar documentation
 This is the official sofar documentation. For examples on how to use sofa
 refer to the :ref:`quick_tour`.
 
-.. automodule:: sofar.sofar
+.. automodule:: sofar
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
Minor bug, does not occur on the current main branch.

Required for merging #34, as build will fail otherwise.