### PR TITLE
Update verification rules

### DIFF
--- a/sofar/sofa.py
+++ b/sofar/sofa.py
@@ -876,6 +876,29 @@ class Sofa():
                 "PRIVATE, API, or GLOBAL:\n")
             error_msg += current_error
 
+        # check names of custom data (shall not have the same name as
+        # normative data contained in the convention AES69-2022 Sec. 5.3)
+        current_error = ""
+        if hasattr(self, "_custom"):
+
+            # get normative variables and attributes
+            normative = sf.Sofa(
+                self.GLOBAL_SOFAConventions,
+                version=self.GLOBAL_SOFAConventionsVersion)._convention.keys()
+            normative = [n.replace("GLOBAL_", "") for n in normative]
+
+            # compare against custom
+            for key in self._custom.keys():
+                if key.replace("GLOBAL_", "") in normative:
+                    current_error += "- " + key + "\n"
+
+        if current_error:
+            error_msg += (
+                "Detected custom variable or attribute with reserved names. "
+                "Custom data shall not have the same name as data contained in"
+                " the convention itself:\n")
+            error_msg += current_error
+
         # ---------------------------------------------------------------------
         # 4. Get dimensions (E, R, M, N, S, c, I, and custom)
 

--- a/tests/test_sofa_verify.py
+++ b/tests/test_sofa_verify.py
@@ -324,6 +324,19 @@ def test_wrong_name():
         sofa.verify()
 
 
+def test_custom_data_name():
+    """
+    Custom entries can not have the names of data contained in the convention.
+    """
+
+    sofa = sf.Sofa("GeneralTF")
+    # add variable Origin, although GLOBAL_Origin exists
+    sofa.add_variable("Origin", 1, "double", 'I')
+    with raises(ValueError,
+                match="custom variable or attribute with reserved names"):
+        sofa.verify()
+
+
 # 4 + 5. get and verify dimensions of data ------------------------------------
 def test_wrong_shape():
 


### PR DESCRIPTION
AES69-2022 will restrict the names of custom data. This new rule is added and tested:
Custom data can not have the same name as a variable or attribute contained in the respective convention.