### PR TITLE
Issue warning for preliminary conventions

### DIFF
--- a/sofar/sofa.py
+++ b/sofar/sofa.py
@@ -1172,6 +1172,15 @@ class Sofa():
             else:
                 warning_msg += msg
 
+        # warn if preliminary conventions versions are used
+        if float(self.GLOBAL_SOFAConventionsVersion) < 1.0:
+            warning_msg += (
+                "\n\nDetected preliminary conventions version "
+                f"{self.GLOBAL_SOFAConventionsVersion}:\n - Upgrade data to "
+                "version >= 1.0 if possible. Preliminary conventions might "
+                "change in the future, which could invalidate data that was "
+                "written before the changes.")
+
         # ---------------------------------------------------------------------
         # 9. handle warnings and errors
         if issue_handling != "ignore":

--- a/tests/test_sofa_verify.py
+++ b/tests/test_sofa_verify.py
@@ -488,3 +488,10 @@ def test_deprecations(file):
 
     with raises(ValueError, match=msg):
         sofa.verify(mode="write")
+
+
+def test_preliminary_conventions_version():
+    """Test if using a convention version < 1.0 issues a warning"""
+
+    with pytest.warns(UserWarning, match="Detected preliminary"):
+        sf.Sofa("SingleRoomDRIR", version="0.3")


### PR DESCRIPTION
sofar now issues a warning if creating, reading, or writing data with a convention version < 1.0