### PR TITLE
Read the docs config update

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -15,6 +20,5 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.10
   install:
     - requirements: requirements_dev.txt


### PR DESCRIPTION
The old config style does not support setting python versions >= 3.9
The main branch uses version 3.7, which is still supported.

Documentation for this branch:
https://sofar.readthedocs.io/en/bugfix-rtd_config_update/