### PR TITLE
Refactorings for road to 1.0 PR

### DIFF
--- a/sofar/__init__.py
+++ b/sofar/__init__.py
@@ -8,7 +8,7 @@ __version__ = '0.3.1'
 
 from .sofa import Sofa
 
-from .io import (read_sofa, write_sofa)
+from .io import read_sofa, write_sofa
 
 from .utils import (list_conventions,
                     equals,

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -221,7 +221,7 @@ def _write_sofa(filename: str, sofa: sf.Sofa, compression=4, verify=True):
                            f"data with version {latest}."))
 
     # setting the netCDF compression parameter
-    zlib = False if compression == 0 else True
+    use_zlib = compression != 0
 
     # update the dimensions
     if verify:
@@ -267,7 +267,7 @@ def _write_sofa(filename: str, sofa: sf.Sofa, compression=4, verify=True):
             shape = tuple(list(sofa._dimensions[key]))
             tmp_var = file.createVariable(
                 key.replace("Data_", "Data."), dtype, shape,
-                zlib=zlib, complevel=compression)
+                zlib=use_zlib, complevel=compression)
             if dtype == "f8":
                 tmp_var[:] = value
             else:

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import numpy as np
 from netCDF4 import Dataset, chartostring, stringtochar
@@ -307,10 +308,8 @@ def _format_value_for_netcdf(value, key, dtype, dimensions, S):
         'f8', or 'S1').
     """
     # copy value
-    try:
+    with contextlib.suppress(AttributeError):
         value = value.copy()
-    except AttributeError:
-        pass
 
     # parse data
     if dtype == "attribute":

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -91,15 +91,15 @@ def read_sofa(filename, verify=True, verbose=True):
                 continue
 
             value = getattr(file, attr)
-            all_attr.append("GLOBAL_" + attr)
+            all_attr.append(f"GLOBAL_{attr}")
 
-            if not hasattr(sofa, "GLOBAL_" + attr):
-                sofa._add_custom_api_entry("GLOBAL_" + attr, value, None,
-                                           None, "attribute")
-                custom.append("GLOBAL_" + attr)
+            if not hasattr(sofa, f"GLOBAL_{attr}"):
+                sofa._add_custom_api_entry(
+                    f"GLOBAL_{attr}", value, None, None, "attribute")
+                custom.append(f"GLOBAL_{attr}")
                 sofa._protected = False
             else:
-                setattr(sofa, "GLOBAL_" + attr, value)
+                setattr(sofa, f"GLOBAL_{attr}", value)
 
         # load data
         for var in file.variables.keys():
@@ -320,7 +320,7 @@ def _format_value_for_netcdf(value, key, dtype, dimensions, S):
         value = _atleast_nd(value, len(dimensions))
         netcdf_dtype = "f8"
     elif dtype == "string":
-        value = np.array(value, dtype="S" + str(S))
+        value = np.array(value, dtype=f"S{str(S)}")
         value = _atleast_nd(value, len(dimensions))
         netcdf_dtype = 'S1'
     else:

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -110,7 +110,7 @@ def read_sofa(filename, verify=True, verbose=True):
             if hasattr(sofa, var.replace(".", "_")):
                 setattr(sofa, var.replace(".", "_"), value)
             else:
-                dimensions = "".join([d for d in file[var].dimensions])
+                dimensions = "".join(list(file[var].dimensions))
                 # SOFA only uses dtypes 'double' and 'S1' but netCDF has more
                 dtype = "string" if file[var].datatype == "S1" else "double"
                 sofa._add_custom_api_entry(var.replace(".", "_"), value, None,
@@ -264,7 +264,7 @@ def _write_sofa(filename: str, sofa: sf.Sofa, compression=4, verify=True):
                 sofa._dimensions[key], sofa._api["S"])
 
             # create variable and write data
-            shape = tuple([dim for dim in sofa._dimensions[key]])
+            shape = tuple(list(sofa._dimensions[key]))
             tmp_var = file.createVariable(
                 key.replace("Data_", "Data."), dtype, shape,
                 zlib=zlib, complevel=compression)
@@ -275,7 +275,7 @@ def _write_sofa(filename: str, sofa: sf.Sofa, compression=4, verify=True):
                 tmp_var._Encoding = "ascii"
 
             # write variable attributes
-            sub_keys = [k for k in all_keys if k.startswith(key + "_")]
+            sub_keys = [k for k in all_keys if k.startswith(f"{key}_")]
             for sub_key in sub_keys:
                 setattr(tmp_var, sub_key[len(key)+1:],
                         str(getattr(sofa, sub_key)))

--- a/sofar/update_conventions.py
+++ b/sofar/update_conventions.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import glob
 import json
@@ -248,11 +249,8 @@ def _convention_csv2dict(file: str):
                 # parse text cells that do not contain arrays
                 if cell[0] != '[':
                     # check for numbers
-                    try:
+                    with contextlib.suppress(ValueError):
                         cell = float(cell) if '.' in cell else int(cell)
-                    except ValueError:
-                        pass
-
                     line[idc] = cell
                     continue
 

--- a/sofar/update_conventions.py
+++ b/sofar/update_conventions.py
@@ -100,12 +100,15 @@ def update_conventions(conventions_path=None, assume_yes=False):
             continue
 
         # get filename and url
-        is_standardized = True if convention in standardized else False
+        is_standardized = convention in standardized
         standardized_csv = os.path.join(conventions_path, convention)
         deprecated_csv = os.path.join(
                 conventions_path, "deprecated", convention)
-        url = urls[0] + "/" + convention if is_standardized \
-            else urls[1] + "/" + convention
+        url = (
+            f"{urls[0]}/{convention}"
+            if is_standardized
+            else f"{urls[1]}/{convention}"
+        )
 
         # download SOFA convention definitions to package directory
         data = requests.get(url)
@@ -136,7 +139,7 @@ def update_conventions(conventions_path=None, assume_yes=False):
             with open(deprecated_csv, "wb") as file:
                 file.write(data)
             os.remove(standardized_csv)
-            os.remove(standardized_csv[:-3] + "json")
+            os.remove(f"{standardized_csv[:-3]}json")
             print(f"- deprecated convention: {convention[:-4]}")
         elif not is_standardized and os.path.isfile(deprecated_csv):
             # check for update of a deprecated convention
@@ -192,7 +195,7 @@ def _compile_conventions(conventions_path=None):
 
         # convert SOFA conventions from csv to json
         convention_dict = _convention_csv2dict(csv_file)
-        with open(csv_file[:-3] + "json", 'w') as file:
+        with open(f"{csv_file[:-3]}json", 'w') as file:
             json.dump(convention_dict, file, indent=4)
 
 

--- a/sofar/update_conventions.py
+++ b/sofar/update_conventions.py
@@ -321,7 +321,7 @@ def _convention_csv2dict(file: str):
 
     # reorder the fields to be nicer to read and understand
     # 1. Move everything to the end that is not GLOBAL
-    keys = [key for key in convention.keys()]
+    keys = list(convention.keys())
     for key in keys:
         if "GLOBAL" not in key:
             convention[key] = convention.pop(key)

--- a/sofar/utils.py
+++ b/sofar/utils.py
@@ -200,19 +200,15 @@ def equals(sofa_a, sofa_b, verbose=True, exclude=None):
 
     # check for equal length
     if len(keys_a) != len(keys_b):
-        is_identical = _equals_raise_warning((
+        return _equals_raise_warning((
             f"not identical: sofa_a has {len(keys_a)} attributes for "
             f"comparison and sofa_b has {len(keys_b)}."), verbose)
 
-        return is_identical
-
     # check if the keys match
     if set(keys_a) != set(keys_b):
-        is_identical = _equals_raise_warning(
+        return _equals_raise_warning(
             "not identical: sofa_a and sofa_b do not have the ame attributes",
             verbose)
-
-        return is_identical
 
     # compare the data inside the SOFA object
     for key in keys_a:

--- a/sofar/utils.py
+++ b/sofar/utils.py
@@ -120,11 +120,9 @@ def _get_conventions(return_type, conventions_path=None):
     reg_str = "*.csv" if return_type == "path_source" else "*.json"
 
     # SOFA convention files
-    standardized = [
-        f for f in glob.glob(os.path.join(conventions_path, reg_str))]
-    deprecated = [
-        f for f in glob.glob(os.path.join(
-            conventions_path, "deprecated", reg_str))]
+    standardized = list(glob.glob(os.path.join(conventions_path, reg_str)))
+    deprecated = list(
+        glob.glob(os.path.join(conventions_path, "deprecated", reg_str)))
     paths = standardized + deprecated
 
     conventions_str = "Available SOFA conventions:\n"
@@ -144,7 +142,7 @@ def _get_conventions(return_type, conventions_path=None):
     elif return_type == "name":
         return conventions
     elif return_type == "name_version":
-        return [(n, v) for n, v in zip(conventions, versions)]
+        return list(zip(conventions, versions))
     elif return_type == "string":
         return conventions_str
     else:

--- a/sofar/utils.py
+++ b/sofar/utils.py
@@ -57,11 +57,7 @@ def _verify_convention_and_version(version, version_in, convention):
                    f"{version_in} to {version_out}"))
     else:
         # check which version is wanted
-        if version == "match":
-            match = version_in
-        else:
-            match = version
-
+        match = version_in if version == "match" else version
         version_out = None
         for versions in name_version:
             # check if convention and version match


### PR DESCRIPTION
- use list constructor instead of loops and list comprehensions
- use contextlib to suppress exceptions
- use f-strings instead of string concatenations

Judging by the time it takes to run the tests, this improves performance by a bit, but not much. Also made parts of the code more compact.