### PR TITLE
Add a general `read_netcdf` function to read corrupted SOFA data

### DIFF
--- a/sofar/__init__.py
+++ b/sofar/__init__.py
@@ -8,7 +8,7 @@ __version__ = '0.3.1'
 
 from .sofa import Sofa
 
-from .io import read_sofa, write_sofa
+from .io import read_sofa, read_netcdf, write_sofa
 
 from .utils import (list_conventions,
                     equals,
@@ -21,6 +21,7 @@ __all__ = ['Sofa',
            'update_conventions',
            'list_conventions',
            'read_sofa',
+           'read_netcdf',
            'write_sofa',
            'equals',
            'version']

--- a/sofar/__init__.py
+++ b/sofar/__init__.py
@@ -8,7 +8,7 @@ __version__ = '1.0.0'
 
 from .sofa import Sofa
 
-from .io import read_sofa, read_netcdf, write_sofa
+from .io import read_sofa, read_sofa_as_netcdf, write_sofa
 
 from .utils import (list_conventions,
                     equals,
@@ -21,7 +21,7 @@ __all__ = ['Sofa',
            'update_conventions',
            'list_conventions',
            'read_sofa',
-           'read_netcdf',
+           'read_sofa_as_netcdf',
            'write_sofa',
            'equals',
            'version']

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -55,7 +55,7 @@ def read_sofa(filename, verify=True, verbose=True):
     return _read_netcdf(filename, verify, verbose, mode="sofa")
 
 
-def read_netcdf(filename, verbose=True):
+def read_netcdf(filename):
     """
     Read NetCDF file from disk and convert it to SOFA object.
 

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -250,22 +250,25 @@ def _write_sofa(filename: str, sofa: sf.Sofa, compression=4, verify=True):
     write_sofa for documentation.
     """
 
-    # check the filename
-    if not filename.endswith('.sofa'):
-        raise ValueError("Filename must end with .sofa")
+    if verify:
+        # check the filename
+        if not filename.endswith('.sofa'):
+            raise ValueError("Filename must end with .sofa")
 
-    # check if the latest version is used for writing and warn otherwise
-    # if case required for writing SOFA test data that violates the conventions
-    if sofa.GLOBAL_SOFAConventions != "invalid-value":
-        latest = sf.Sofa(sofa.GLOBAL_SOFAConventions)
-        latest = latest.GLOBAL_SOFAConventionsVersion
-        current = sofa.GLOBAL_SOFAConventionsVersion
+        # check if the latest version is used for writing and warn otherwise
+        # if case required for writing SOFA test data that violates the
+        # conventions
+        if sofa.GLOBAL_SOFAConventions != "invalid-value":
+            latest = sf.Sofa(sofa.GLOBAL_SOFAConventions)
+            latest = latest.GLOBAL_SOFAConventionsVersion
+            current = sofa.GLOBAL_SOFAConventionsVersion
 
-        if parse(current) < parse(latest):
-            warnings.warn(("Writing SOFA object with outdated Convention "
-                           f"version {current}. It is recommend to upgrade "
-                           " data with Sofa.upgrade_convention() before "
-                           "writing to disk if possible."))
+            if parse(current) < parse(latest):
+                warnings.warn((
+                    "Writing SOFA object with outdated Convention "
+                    f"version {current}. It is recommend to upgrade "
+                    " data with Sofa.upgrade_convention() before "
+                    "writing to disk if possible."))
 
     # setting the netCDF compression parameter
     use_zlib = compression != 0

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -132,7 +132,7 @@ def _read_netcdf(filename, verify, verbose, mode):
             sofa = sf.Sofa(None)
 
         # allow writing read only attributes
-        sofa._protected = False
+        sofa.protected = False
 
         # load global attributes
         for attr in file.ncattrs():
@@ -144,7 +144,7 @@ def _read_netcdf(filename, verify, verbose, mode):
                 sofa._add_custom_api_entry(
                     f"GLOBAL_{attr}", value, None, None, "attribute")
                 custom.append(f"GLOBAL_{attr}")
-                sofa._protected = False
+                sofa.protected = False
             else:
                 setattr(sofa, f"GLOBAL_{attr}", value)
 
@@ -163,7 +163,7 @@ def _read_netcdf(filename, verify, verbose, mode):
                 sofa._add_custom_api_entry(var.replace(".", "_"), value, None,
                                            dimensions, dtype)
                 custom.append(var.replace(".", "_"))
-                sofa._protected = False
+                sofa.protected = False
 
             # load variable attributes
             for attr in [a for a in file[var].ncattrs() if a not in skip]:
@@ -176,7 +176,7 @@ def _read_netcdf(filename, verify, verbose, mode):
                         var.replace(".", "_") + "_" + attr, value, None,
                         None, "attribute")
                     custom.append(var.replace(".", "_") + "_" + attr)
-                    sofa._protected = False
+                    sofa.protected = False
                 else:
                     setattr(sofa, var.replace(".", "_") + "_" + attr, value)
 
@@ -188,7 +188,7 @@ def _read_netcdf(filename, verify, verbose, mode):
             delattr(sofa, attr)
 
     # do not allow writing read only attributes any more
-    sofa._protected = True
+    sofa.protected = True
 
     # notice about custom entries
     if custom and verbose:

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -18,8 +18,7 @@ def read_sofa(filename, verify=True, verbose=True):
     Parameters
     ----------
     filename : str
-        The filename. '.sofa' is appended to the filename, if it is not
-        explicitly given.
+        The full path to the sofa data.
     verify : bool, optional
         Verify and update the SOFA object by calling :py:func:`~Sofa.verify`.
         This helps to find potential errors in the default values and is thus
@@ -32,7 +31,7 @@ def read_sofa(filename, verify=True, verbose=True):
     Returns
     -------
     sofa : Sofa
-        The SOFA object filled with the default values of the convention.
+        A SOFA object containing the data from `filename`.
 
     Notes
     -----
@@ -60,10 +59,16 @@ def read_netcdf(filename):
     Read NetCDF file from disk and convert it to SOFA object.
 
     .. note::
-        This intended to read and fix corrupted SOFA data that could not be
-        read otherwise. The returned SOFA object may not work correctly unless
-        the data was corrected and is in agreement with the SOFA standard
-        AES-69-
+        `read_netcdf` is intended to read and fix corrupted SOFA data that
+        could not be read by :py:func:`~read_sofa`. The recommend workflow is
+
+        - Try to read the data with `read_sofa` and ``verify=True``
+        - If this fails, try the above with ``verify=False``
+        - If this fails, use `read_netcdf`
+
+        The SOFA object  returned by `read_netcdf` may not work correctly
+        before the issues with the data were fixed, i.e., before the data are
+        in agreement with the SOFA standard AES-69.
 
     Numeric data is returned as floats or numpy float arrays unless they have
     missing data, in which case they are returned as numpy masked arrays.
@@ -71,13 +76,12 @@ def read_netcdf(filename):
     Parameters
     ----------
     filename : str
-        The filename. '.sofa' is appended to the filename, if it is not
-        explicitly given.
+        The full path to the NetCDF data.
 
     Returns
     -------
     sofa : Sofa
-        The SOFA object filled with the default values of the convention.
+        A SOFA object containing the data from `filename`.
 
     Notes
     -----

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -263,8 +263,9 @@ def _write_sofa(filename: str, sofa: sf.Sofa, compression=4, verify=True):
 
         if parse(current) < parse(latest):
             warnings.warn(("Writing SOFA object with outdated Convention "
-                           f"version {current}. Use version='latest' to write "
-                           f"data with version {latest}."))
+                           f"version {current}. It is recommend to upgrade "
+                           " data with Sofa.upgrade_convention() before "
+                           "writing to disk if possible."))
 
     # setting the netCDF compression parameter
     use_zlib = compression != 0

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -31,7 +31,7 @@ def read_sofa(filename, verify=True, verbose=True):
     Returns
     -------
     sofa : Sofa
-        A SOFA object containing the data from `filename`.
+        Object containing the data from `filename`.
 
     Notes
     -----
@@ -54,21 +54,22 @@ def read_sofa(filename, verify=True, verbose=True):
     return _read_netcdf(filename, verify, verbose, mode="sofa")
 
 
-def read_netcdf(filename):
+def read_sofa_as_netcdf(filename):
     """
-    Read NetCDF file from disk and convert it to SOFA object.
+    Read corrupted SOFA data from disk.
 
     .. note::
-        `read_netcdf` is intended to read and fix corrupted SOFA data that
-        could not be read by :py:func:`~read_sofa`. The recommend workflow is
+        `read_sofa_as_netcdf` is intended to read and fix corrupted SOFA data
+        that could not be read by :py:func:`~read_sofa`. The recommend workflow
+        is
 
         - Try to read the data with `read_sofa` and ``verify=True``
         - If this fails, try the above with ``verify=False``
-        - If this fails, use `read_netcdf`
+        - If this fails, use `read_sofa_as_netcdf`
 
-        The SOFA object  returned by `read_netcdf` may not work correctly
-        before the issues with the data were fixed, i.e., before the data are
-        in agreement with the SOFA standard AES-69.
+        The SOFA object  returned by `read_sofa_as_netcdf` may not work
+        correctly before the issues with the data were fixed, i.e., before the
+        data are in agreement with the SOFA standard AES-69.
 
     Numeric data is returned as floats or numpy float arrays unless they have
     missing data, in which case they are returned as numpy masked arrays.
@@ -81,7 +82,7 @@ def read_netcdf(filename):
     Returns
     -------
     sofa : Sofa
-        A SOFA object containing the data from `filename`.
+        Object containing the data from `filename`.
 
     Notes
     -----

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 from netCDF4 import Dataset, chartostring, stringtochar
 import warnings
-import packaging
+from packaging.version import parse
 import sofar as sf
 from .utils import _verify_convention_and_version, _atleast_nd
 
@@ -120,14 +120,13 @@ def _read_netcdf(filename, verify, verbose, mode):
         if mode == "sofa":
             # get convention name and version
             convention = getattr(file, "SOFAConventions")
-            version_in = getattr(file, "SOFAConventionsVersion")
+            version = getattr(file, "SOFAConventionsVersion")
 
             # check if convention and version exist
-            version_out = _verify_convention_and_version(
-                version_in, version_in, convention)
+            _verify_convention_and_version(version, convention)
 
             # get SOFA object with default values
-            sofa = sf.Sofa(convention, version=version_out, verify=verify)
+            sofa = sf.Sofa(convention, version=version, verify=verify)
         else:
             sofa = sf.Sofa(None)
 
@@ -262,7 +261,7 @@ def _write_sofa(filename: str, sofa: sf.Sofa, compression=4, verify=True):
         latest = latest.GLOBAL_SOFAConventionsVersion
         current = sofa.GLOBAL_SOFAConventionsVersion
 
-        if packaging.version.parse(current) < packaging.version.parse(latest):
+        if parse(current) < parse(latest):
             warnings.warn(("Writing SOFA object with outdated Convention "
                            f"version {current}. Use version='latest' to write "
                            f"data with version {latest}."))

--- a/sofar/sofa.py
+++ b/sofar/sofa.py
@@ -297,7 +297,8 @@ class Sofa():
 
         # update the private attribute `_convention` to make sure the required
         # meta data is in place
-        self._reset_convention()
+        if not hasattr(self, "_convention"):
+            self._reset_convention()
 
         # list of all attributes
         keys = [k for k in self.__dict__.keys() if not k.startswith("_")]

--- a/sofar/sofa.py
+++ b/sofar/sofa.py
@@ -89,23 +89,27 @@ class Sofa():
         """See class docstring"""
 
         # get convention
-        self._convention = self._load_convention(convention, version)
+        if convention is not None:
+            self._convention = self._load_convention(convention, version)
 
-        # update read only attributes
-        self._read_only_attr = [
-            key for key in self._convention.keys()
-            if self._read_only(self._convention[key]["flags"])]
+            # update read only attributes
+            self._read_only_attr = [
+                key for key in self._convention.keys()
+                if self._read_only(self._convention[key]["flags"])]
 
-        # add attributes with default values
-        self._convention_to_sofa(mandatory)
+            # add attributes with default values
+            self._convention_to_sofa(mandatory)
 
-        # add and update the API
-        # (mandatory=False can not be verified because some conventions have
-        # default values that have optional variables as dependencies)
-        if verify and not mandatory:
-            self.verify(mode="read")
+            # add and update the API
+            # (mandatory=False can not be verified because some conventions
+            # have default values that have optional variables as dependencies)
+            if verify and not mandatory:
+                self.verify(mode="read")
 
-        self._protected = True
+            self._protected = True
+        else:
+            verify = False
+            self._convention = {}
 
     def __setattr__(self, name: str, value):
         # don't allow new attributes to be added outside the class

--- a/sofar/sofa.py
+++ b/sofar/sofa.py
@@ -652,7 +652,7 @@ class Sofa():
                 "type": dtype,
                 "default": None,
                 "comment": ""}
-        self._reset_convention()
+            self._convention[key] = self._custom[key]
 
         # add attribute to object
         setattr(self, key, value)

--- a/sofar/sofa.py
+++ b/sofar/sofa.py
@@ -118,7 +118,10 @@ class Sofa():
 
         # don't allow setting read only attributes
         if name in self._read_only_attr and self.protected:
-            raise TypeError(f"{name} is a read only attribute")
+            raise TypeError((
+                f"{name} is a read only attribute. Iy you know what you are "
+                "doing, you can set Sofa.protected = False to write read "
+                "only data (e.g., to repair corrupted SOFA data)."))
 
         # convert to numpy array or scalar
         if not isinstance(value, (str, dict, np.ndarray)) \

--- a/sofar/sofa.py
+++ b/sofar/sofa.py
@@ -1592,7 +1592,7 @@ class Sofa():
         c_current = self.GLOBAL_SOFAConventions
         v_current = str(self.GLOBAL_SOFAConventionsVersion)
 
-        _verify_convention_and_version("match", v_current, c_current)
+        _verify_convention_and_version(v_current, c_current)
 
         # load and add convention and version
         convention = self._load_convention(

--- a/sofar/utils.py
+++ b/sofar/utils.py
@@ -48,8 +48,9 @@ def _verify_convention_and_version(version, convention):
     if not version_exists:
         raise ValueError((
             f"{convention} v{version} is not a valid SOFA Convention."
-            "If you are trying to read the data use sofar.read_netcdf(). "
-            "Call sofar.list_conventions() for a list of valid Conventions"))
+            "If you are trying to read the data use "
+            "sofar.read_sofa_as_netcdf(). Call sofar.list_conventions() for a "
+            "list of valid Conventions"))
 
 
 def list_conventions():

--- a/sofar/utils.py
+++ b/sofar/utils.py
@@ -67,8 +67,10 @@ def _verify_convention_and_version(version, version_in, convention):
 
         if version_out is None:
             raise ValueError((
-                f"Version {match} does not exist for convention {convention}. "
-                "Try to access the data with version='latest'"))
+                f"{convention} v{match} is not a valid SOFA Convention."
+                "If you are trying to read the data use sofar.read_netcdf(). "
+                "Call sofar.list_conventions() for a list of valid Conventions"
+                ))
 
     return version_out
 

--- a/sofar/utils.py
+++ b/sofar/utils.py
@@ -2,7 +2,6 @@ import os
 import glob
 import numpy as np
 import numpy.testing as npt
-from packaging.version import parse as version_parse
 import warnings
 import sofar as sf
 
@@ -19,60 +18,38 @@ def version():
             f"SOFA standard {sofa_conventions}")
 
 
-def _verify_convention_and_version(version, version_in, convention):
+def _verify_convention_and_version(version, convention):
     """
-    Verify if convention and version exist and return version
+    Verify if convention and version exist. Raise a Value error if it does not.
 
     Parameters
     ----------
     version : str
-        'latest', 'match', version string (e.g., '1.0')
-    version_in : str
-        The version to be checked against
+        The version to be checked
     convention : str
         The name of the convention to be checked
-
-    Returns
-    -------
-    version_out : str
-        The version to be used depending on `version`, and `version_in`
     """
 
-    # check if the convention exists in sofar
+    # check if the convention exists
     if convention not in _get_conventions("name"):
         raise ValueError(
             f"Convention '{convention}' does not exist")
 
     name_version = _get_conventions("name_version")
 
-    if version == "latest":
-        # get list of versions as floats
-        version_out = [float(versions[1]) for versions in name_version
-                       if versions[0] == convention]
-        # get latest version as string
-        version_out = str(version_out[np.argmax(version_out)])
+    # check which version is wanted
+    version_exists = False
+    for versions in name_version:
+        # check if convention and version match
+        if versions[0] == convention \
+                and str(float(versions[1])) == version:
+            version_exists = True
 
-        if version_parse(version_out) > version_parse(version_in):
-            print(("Updated conventions version from "
-                   f"{version_in} to {version_out}"))
-    else:
-        # check which version is wanted
-        match = version_in if version == "match" else version
-        version_out = None
-        for versions in name_version:
-            # check if convention and version match
-            if versions[0] == convention \
-                    and str(float(versions[1])) == match:
-                version_out = str(float(versions[1]))
-
-        if version_out is None:
-            raise ValueError((
-                f"{convention} v{match} is not a valid SOFA Convention."
-                "If you are trying to read the data use sofar.read_netcdf(). "
-                "Call sofar.list_conventions() for a list of valid Conventions"
-                ))
-
-    return version_out
+    if not version_exists:
+        raise ValueError((
+            f"{convention} v{version} is not a valid SOFA Convention."
+            "If you are trying to read the data use sofar.read_netcdf(). "
+            "Call sofar.list_conventions() for a list of valid Conventions"))
 
 
 def list_conventions():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -101,7 +101,7 @@ def test_read_netcdf():
         # can not be read with read_sofa
         with raises(ValueError):
             sf.read_sofa(file)
-        sofa_read = sf.read_netcdf(file)
+        sofa_read = sf.read_sofa_as_netcdf(file)
         sf.equals(sofa, sofa_read)
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -83,6 +83,28 @@ def test_read_sofa_custom_data():
     assert sofa.GLOBAL_Warming == 'critical'
 
 
+def test_read_netcdf():
+    tmp = TemporaryDirectory()
+    files = [os.path.join(tmp.name, "invalid.sofa"),
+             os.path.join(tmp.name, "invalid.netcdf")]
+
+    # create data with invalid SOFA convention and version
+    sofa = sf.Sofa("GeneralTF")
+    sofa.protected = False
+    sofa.GLOBAL_SOFAConventions = "MadeUp"
+    sofa.protected = True
+
+    # test reading
+    for file in files:
+        # write data
+        sf.io._write_sofa(file, sofa, verify=False)
+        # can not be read with read_sofa
+        with raises(ValueError):
+            sf.read_sofa(file)
+        sofa_read = sf.read_netcdf(file)
+        sf.equals(sofa, sofa_read)
+
+
 def test_write_sofa_assertion():
     """Test assertion for wrong filename ending"""
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -47,7 +47,7 @@ def test_read_sofa(capfd):
     with Dataset(filename, "r+", format="NETCDF4") as file:
         setattr(file, "SOFAConventionsVersion", "0.1")
     # ValueError when version should be matched
-    with raises(ValueError, match="Version 0.1 does not exist for"):
+    with raises(ValueError, match="v0.1 is not a valid SOFA Convention"):
         sf.read_sofa(filename)
 
     # read file containing a variable with wrong shape
@@ -312,9 +312,9 @@ def test_verify_convention_and_version():
     # test assertions
     with raises(ValueError, match="Convention 'Funky' does not exist"):
         _verify_convention_and_version("latest", "1.0", "Funky")
-    with raises(ValueError, match="Version 1.1 does not exist"):
+    with raises(ValueError, match="v1.1 is not a valid SOFA Convention"):
         _verify_convention_and_version("match", "1.1", "GeneralTF")
-    with raises(ValueError, match="Version 1.2 does not exist"):
+    with raises(ValueError, match="v1.2 is not a valid SOFA Convention"):
         _verify_convention_and_version("1.2", "1.0", "GeneralTF")
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -299,23 +299,15 @@ def test_format_value_from_netcdf():
 
 def test_verify_convention_and_version():
 
-    # test different possibilities for version
-    version = _verify_convention_and_version("latest", "1.0", "GeneralTF")
-    assert version == "2.0"
-
-    version = _verify_convention_and_version("2.0", "1.0", "GeneralTF")
-    assert version == "2.0"
-
-    version = _verify_convention_and_version("match", "1.0", "GeneralTF")
-    assert version == "1.0"
+    # test with existing convention and version (no error returns None)
+    out = _verify_convention_and_version("1.0", "GeneralTF")
+    assert out is None
 
     # test assertions
     with raises(ValueError, match="Convention 'Funky' does not exist"):
-        _verify_convention_and_version("latest", "1.0", "Funky")
+        _verify_convention_and_version("1.0", "Funky")
     with raises(ValueError, match="v1.1 is not a valid SOFA Convention"):
-        _verify_convention_and_version("match", "1.1", "GeneralTF")
-    with raises(ValueError, match="v1.2 is not a valid SOFA Convention"):
-        _verify_convention_and_version("1.2", "1.0", "GeneralTF")
+        _verify_convention_and_version("1.1", "GeneralTF")
 
 
 def test_atleast_nd():

--- a/tests/test_sofa.py
+++ b/tests/test_sofa.py
@@ -231,9 +231,9 @@ def test_add_entry():
     assert "Temperature_Units" not in sofa._custom
 
     # test adding missing entry defined in convention
-    sofa._protected = False
+    sofa.protected = False
     delattr(sofa, "ListenerPosition")
-    sofa._protected = True
+    sofa.protected = True
     sofa.add_variable("ListenerPosition", [0, 0, 0], "double", "IC")
     assert "ListenerPosition" not in sofa._custom
 
@@ -273,10 +273,10 @@ def test_add_missing(
     opt = "GLOBAL_History"
 
     # remove data before adding it again
-    sofa._protected = False
+    sofa.protected = False
     sofa.delete(man)
     sofa.delete(opt)
-    sofa._protected = False
+    sofa.protected = False
 
     # add missing data
     sofa.add_missing(mandatory, optional, verbose)

--- a/tests/test_sofa.py
+++ b/tests/test_sofa.py
@@ -313,11 +313,6 @@ def test_delete_entry():
     assert not hasattr(sofa, "SourceManufacturer")
 
 
-def test__update_conventions():
-    """Tested in test_sofa_verify.pi::test_version"""
-    pass
-
-
 def test__get_size_and_shape_of_string_var():
 
     # test with string

--- a/tests/test_sofa_verify.py
+++ b/tests/test_sofa_verify.py
@@ -115,9 +115,9 @@ def test_case_insensitivity():
 
     # data type (must be case sensitive) --------------------------------------
     sofa = sf.Sofa("SimpleFreeFieldHRIR")
-    sofa._protected = False
+    sofa.protected = False
     sofa.GLOBAL_DataType = "fir"
-    sofa._protected = True
+    sofa.protected = True
     with raises(ValueError, match="GLOBAL_DataType is fir"):
         sofa.verify()
 
@@ -153,9 +153,9 @@ def test_missing_default_attributes(capfd):
 
     # test missing default attribute
     sofa = sf.Sofa("GeneralTF")
-    sofa._protected = False
+    sofa.protected = False
     delattr(sofa, "GLOBAL_Conventions")
-    sofa._protected = True
+    sofa.protected = True
 
     # raises error
     with raises(ValueError, match="Detected missing mandatory data"):
@@ -242,42 +242,42 @@ def test_wrong_name():
 
     # attribute with missing variable
     sofa = sf.Sofa("GeneralTF")
-    sofa._protected = False
+    sofa.protected = False
     sofa.IR_Type = "pressure"
     sofa._custom = {"IR_Type": {"default": None,
                                 "flags": None,
                                 "dimensions": None,
                                 "type": "attribute",
                                 "comment": ""}}
-    sofa._protected = True
+    sofa.protected = True
 
     with raises(ValueError, match="Detected attributes with missing"):
         sofa.verify()
 
     # attribute with no underscore
     sofa = sf.Sofa("GeneralTF")
-    sofa._protected = False
+    sofa.protected = False
     sofa.IRType = "pressure"
     sofa._custom = {"IRType": {"default": None,
                                "flags": None,
                                "dimensions": None,
                                "type": "attribute",
                                "comment": ""}}
-    sofa._protected = True
+    sofa.protected = True
 
     with raises(ValueError, match="Detected attribute names with too many"):
         sofa.verify()
 
     # variable with underscore
     sofa = sf.Sofa("GeneralTF")
-    sofa._protected = False
+    sofa.protected = False
     sofa.IR_Data = 1
     sofa._custom = {"IR_Data": {"default": None,
                                 "flags": None,
                                 "dimensions": "IM",
                                 "type": "double",
                                 "comment": ""}}
-    sofa._protected = True
+    sofa.protected = True
 
     with raises(ValueError, match="Detected variable names with too many"):
         sofa.verify()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -146,53 +146,53 @@ def test_equals_global_parameters():
 
     # check different number of keys
     sofa_b = deepcopy(sofa_a)
-    sofa_b._protected = False
+    sofa_b.protected = False
     delattr(sofa_b, "ReceiverPosition")
-    sofa_b._protected = True
+    sofa_b.protected = True
     with pytest.warns(UserWarning, match="not identical: sofa_a has"):
         is_identical = sf.equals(sofa_a, sofa_b)
         assert not is_identical
 
     # check different keys
     sofa_b = deepcopy(sofa_a)
-    sofa_b._protected = False
+    sofa_b.protected = False
     sofa_b.PositionReceiver = sofa_b.ReceiverPosition
     delattr(sofa_b, "ReceiverPosition")
-    sofa_b._protected = True
+    sofa_b.protected = True
     with pytest.warns(UserWarning, match="not identical: sofa_a and sofa_b"):
         is_identical = sf.equals(sofa_a, sofa_b)
         assert not is_identical
 
     # check mismatching data types
     sofa_b = deepcopy(sofa_a)
-    sofa_b._protected = False
+    sofa_b.protected = False
     sofa_b._convention["ReceiverPosition"]["type"] = "int"
-    sofa_b._protected = True
+    sofa_b.protected = True
     with pytest.warns(UserWarning, match="not identical: ReceiverPosition"):
         is_identical = sf.equals(sofa_a, sofa_b)
         assert not is_identical
 
     # check exclude GLOBAL attributes
     sofa_b = deepcopy(sofa_a)
-    sofa_b._protected = False
+    sofa_b.protected = False
     delattr(sofa_b, "GLOBAL_Version")
-    sofa_b._protected = True
+    sofa_b.protected = True
     is_identical = sf.equals(sofa_a, sofa_b, exclude="GLOBAL")
     assert is_identical
 
     # check exclude Date attributes
     sofa_b = deepcopy(sofa_a)
-    sofa_b._protected = False
+    sofa_b.protected = False
     delattr(sofa_b, "GLOBAL_DateModified")
-    sofa_b._protected = True
+    sofa_b.protected = True
     is_identical = sf.equals(sofa_a, sofa_b, exclude="DATE")
     assert is_identical
 
     # check exclude Date attributes
     sofa_b = deepcopy(sofa_a)
-    sofa_b._protected = False
+    sofa_b.protected = False
     delattr(sofa_b, "GLOBAL_DateModified")
-    sofa_b._protected = True
+    sofa_b.protected = True
     is_identical = sf.equals(sofa_a, sofa_b, exclude="ATTR")
     assert is_identical
 
@@ -210,14 +210,14 @@ def test_equals_attribute_values(value_a, value_b, attribute, fails):
 
     # generate SOFA objects (SimpleHeadphoneIR has string variables)
     sofa_a = sf.Sofa("SimpleHeadphoneIR")
-    sofa_a._protected = False
+    sofa_a.protected = False
     sofa_b = deepcopy(sofa_a)
 
     # set parameters
     setattr(sofa_a, attribute, value_a)
-    sofa_a._protected = True
+    sofa_a.protected = True
     setattr(sofa_b, attribute, value_b)
-    sofa_b._protected = True
+    sofa_b.protected = True
 
     # compare
     if fails:


### PR DESCRIPTION
- [x] refactor `Sofa._update_convention` to `Sofa._reset_convention`. The update functionality is already handled elsewhere
- [x] add `read_netcdf`
- [x] rename `Sofa._protected` to `Sofa.protected` and add explaining docstring
- [x] check where the use of `Sofa._reset_convention` is really required
- [x] Improve error messages when reading Sofa files
- [x] Refer to `Sofa.protected` when attempting to write read only data
- [x] add testing