### PR TITLE
Adjust io functions and tests for path objects

### DIFF
--- a/sofar/io.py
+++ b/sofar/io.py
@@ -258,6 +258,7 @@ def _write_sofa(filename: str, sofa: sf.Sofa, compression=4, verify=True):
     # check the filename
     filename = pathlib.Path(filename).with_suffix('.sofa')
 
+    if verify:
         # check if the latest version is used for writing and warn otherwise
         # if case required for writing SOFA test data that violates the
         # conventions

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -4,6 +4,7 @@ import numpy as np
 from netCDF4 import Dataset, chartostring, stringtochar
 import warnings
 import packaging
+import pathlib
 import sofar as sf
 from .utils import _verify_convention_and_version, _atleast_nd
 
@@ -53,8 +54,7 @@ def read_sofa(filename, verify=True, verbose=True):
     """
 
     # check the filename
-    if not filename.endswith('.sofa'):
-        raise ValueError("Filename must end with .sofa")
+    filename = pathlib.Path(filename).with_suffix('.sofa')
     if not os.path.isfile(filename):
         raise ValueError(f"{filename} does not exist")
 
@@ -206,8 +206,7 @@ def _write_sofa(filename: str, sofa: sf.Sofa, compression=4, verify=True):
     """
 
     # check the filename
-    if not filename.endswith('.sofa'):
-        raise ValueError("Filename must end with .sofa")
+    filename = pathlib.Path(filename).with_suffix('.sofa')
 
     # check if the latest version is used for writing and warn otherwise
     # if case required for writing SOFA test data that violates the conventions

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -6,6 +6,7 @@ from sofar.utils import (_get_conventions,
 from sofar.io import (_format_value_for_netcdf,
                       _format_value_from_netcdf)
 import os
+import pathlib
 from tempfile import TemporaryDirectory
 import pytest
 from pytest import raises
@@ -14,7 +15,7 @@ import numpy.testing as npt
 from netCDF4 import Dataset
 
 
-def test_read_sofa(capfd):
+def test_read_write_sofa(capfd):
 
     temp_dir = TemporaryDirectory()
     filename = os.path.join(temp_dir.name, "test.sofa")
@@ -23,6 +24,11 @@ def test_read_sofa(capfd):
     # test defaults
     sf.write_sofa(filename, sofa)
     sofa = sf.read_sofa(filename)
+    assert hasattr(sofa, "_api")
+
+    # test with path object
+    sf.write_sofa(pathlib.Path(filename), sofa)
+    sofa = sf.read_sofa(pathlib.Path(filename))
     assert hasattr(sofa, "_api")
 
     # reading without updating API
@@ -64,10 +70,6 @@ def test_read_sofa(capfd):
     # data can be read without updating API
     sf.read_sofa(filename, verify=False)
 
-    # test assertion for wrong filename
-    with raises(ValueError, match="Filename must end with .sofa"):
-        sf.read_sofa('sofa.exe')
-
 
 def test_read_sofa_custom_data():
     """Test if sofa files with custom data are loaded correctly"""
@@ -81,14 +83,6 @@ def test_read_sofa_custom_data():
     sf.write_sofa(filename, sofa)
     sofa = sf.read_sofa(filename)
     assert sofa.GLOBAL_Warming == 'critical'
-
-
-def test_write_sofa_assertion():
-    """Test assertion for wrong filename ending"""
-
-    sofa = sf.Sofa("SimpleFreeFieldHRIR")
-    with raises(ValueError, match="Filename must end with .sofa"):
-        sf.write_sofa("sofa.exe", sofa)
 
 
 def test_write_sofa_outdated_version():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -107,14 +107,6 @@ def test_read_netcdf():
         sf.equals(sofa, sofa_read)
 
 
-def test_write_sofa_assertion():
-    """Test assertion for wrong filename ending"""
-
-    sofa = sf.Sofa("SimpleFreeFieldHRIR")
-    with raises(ValueError, match="Filename must end with .sofa"):
-        sf.write_sofa("sofa.exe", sofa)
-
-
 def test_write_sofa_outdated_version():
     """Test the warning for writing SOFA files with outdated versions"""
 


### PR DESCRIPTION
make `sofar.io.read` and `sofar.io.write` accept path objects

closes #55 and https://github.com/pyfar/pyfar/issues/437