### PR TITLE
Raise warning in case of diverging conventions across platforms

### DIFF
--- a/sofar/update_conventions.py
+++ b/sofar/update_conventions.py
@@ -333,7 +333,7 @@ def _convention_csv2dict(file: str):
     return convention
 
 
-def _check_congruency(save_dir=None):
+def _check_congruency(save_dir=None, branch="master"):
     """
     SOFA conventions are stored in two different places - is this a good idea?
     They should be identical, but let's find out.
@@ -348,7 +348,7 @@ def _check_congruency(save_dir=None):
 
     urls = ["https://www.sofaconventions.org/conventions/",
             ("https://raw.githubusercontent.com/sofacoustics/SOFAtoolbox/"
-             "master/SOFAtoolbox/conventions/")]
+             f"{branch}/SOFAtoolbox/conventions/")]
     subdirs = ["sofaconventions", "sofatoolbox"]
 
     # check save_dir

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -49,13 +49,14 @@ def test__get_conventions(capfd):
         _get_conventions(return_type="None")
 
 
-def test__congruency(capfd):
+@pytest.mark.parametrize('branch', ['master', 'develop'])
+def test__congruency(capfd, branch):
     """
     Check if conventions from SOFAToolbox and sofaconventions.org are
     identical.
     """
     out, _ = capfd.readouterr()
-    _check_congruency()
+    _check_congruency(branch=branch)
     out, _ = capfd.readouterr()
     if out != "":
         warnings.warn(out, Warning)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ import pytest
 from pytest import raises
 import numpy as np
 from copy import deepcopy
+import warnings
 
 
 def test_list_conventions(capfd):
@@ -56,7 +57,8 @@ def test__congruency(capfd):
     out, _ = capfd.readouterr()
     _check_congruency()
     out, _ = capfd.readouterr()
-    assert out == ""
+    if out != "":
+        warnings.warn(out, Warning)
 
 
 def test_update_conventions(capfd):


### PR DESCRIPTION
This should not raise an error, because Sofatoolbox master might not reflect the latest development state