### PR TITLE
Release v.1.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,11 +130,12 @@ workflows:
                 - "3.8"
                 - "3.9"
                 - "3.10"
+                - "3.11"
       - flake:
           matrix:
             parameters:
               version:
-                - "3.9"
+                - "3.11"
           requires:
             - build_and_test
 
@@ -142,7 +143,7 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.9"
+                - "3.11"
           requires:
             - build_and_test
 
@@ -157,6 +158,7 @@ workflows:
                 - "3.8"
                 - "3.9"
                 - "3.10"
+                - "3.11"
           filters:
             branches:
               ignore: /.*/
@@ -168,7 +170,7 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.9"
+                - "3.11"
           requires:
             - build_and_test
           filters:
@@ -182,7 +184,7 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.9"
+                - "3.11"
           requires:
             - build_and_test
           filters:
@@ -196,7 +198,7 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.9"
+                - "3.11"
           requires:
             - build_and_test
             - flake

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,8 @@ jobs:
       - run:
           name: Sphinx
           command: |
+            git submodule sync --recursive
+            git submodule update --recursive --init
             pip install -e .
             cd docs/
             make html SPHINXOPTS="-W"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,11 @@ build:
   tools:
     python: "3.10"
 
+# include submodule for documenting the SOFA conventions
+submodules:
+  include:
+    - sofar/sofa_conventions
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -178,9 +178,12 @@ before building the documentation.
 Submodules
 ~~~~~~~~~~
 
-To update the submodules containing the conventions and verification rules run
+To update the submodule containing the conventions and verification rules run
 
-$ git submodule update --remote sofar/sofa_conventions
+$ git submodule update --init --recursive
+$ git submodule update --recursive --remote
+
+and then commit the changes
 
 
 Deploying

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 History
 =======
 
+1.1.0 (2023-7-7)
+----------------
+* Deprecate FreeFieldDirectivityTV 1.0 in favor of FreeFieldDirectivityTV 1.1 (according to sofaconventoins.org and AES69-2022)
+* Add `sofar.read_sofa_as_netcdf` for reading SOFA files with erroneous data
+* Document SOFA conventions on https://sofar.readthedocs.io/en/stable/resources/conventions.html. `Sofa.info()` will this be deprecated in sofar v1.3.0
+* `sofar.read_sofa` and `sofar.write_sofa` now accept filenames and path objects
+* Add testing for Python 3.11
+
 1.0.0 (2022-12-16)
 ------------------
 * Use SOFA conventions of version 2.1 from https://github.com/pyfar/sofa_conventions

--- a/README.rst
+++ b/README.rst
@@ -55,5 +55,5 @@ format*, Audio Engineering Society, Inc., New York, NY, USA.
 
 P. Majdak, F. Zotter, F. Brinkmann, J. De Muynke, M. Mihocic, and M.
 Noisternig, "Spatially Oriented Format for Acoustics 2.1: Introduction and
-Recent Advances,” *J. Audio Eng. Soc.*, vol. 70, no. 7/8, pp. 565–584,
+Recent Advances", *J. Audio Eng. Soc.*, vol. 70, no. 7/8, pp. 565-584,
 Jul. 2022. DOI: https://doi.org/10.17743/jaes.2022.0026

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,8 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
 
-import sofar
+import sofar  # noqa
+import resources.conventions  # noqa: build conventions for documentation
 
 # -- General configuration ---------------------------------------------
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,8 +6,12 @@ Quick tour of SOFA and sofar
 If you are new to SOFA and/or sofar, this is a good place to start. SOFA is
 short for *Spatially Oriented Format for Acoustics* and is an open file format
 for saving acoustic data, as for example head-related impulse responses
-(HRIRs). A good places to get more information about SOFA is
-`sofaconventions.org`_.
+(HRIRs). A good places to get more information about SOFA are
+
+* :ref:`Documentation of the SOFA conventions <conventions_introduction>`
+* The `SOFA paper <https://doi.org/10.17743/jaes.2022.0026>`_
+* `sofaconventions.org`_.
+* The SOFA standard `AES69-2022 <https://www.aes.org/publications/standards/search.cfm?docID=99>`_
 
 Creating SOFA objects
 =====================
@@ -37,32 +41,15 @@ also return a sofa object that has only the mandatory attributes. However, it
 is recommended to start with all attributes and discard empty optional
 attributes before saving the data.
 
+.. _getting_information_about_SOFA_objects:
+
 Getting information about SOFA objects
 ======================================
 
-There are a couple of functions to get a quick insight into SOFA objects that
-are explained in more detail below
+To get an overview of the convention, go to the
+:ref:`documentation of the SOFA conventions <conventions_introduction>`.
 
-* ``sofa.info`` gives you information about the convention (what data must be
-  provided, what data is optional, what shapes can the data have). This is
-  helpful when creating a new SOFA object.
-* ``sofa.inspect`` prints the data stored in a SOFA object or at least gives
-  the shape in case of large arrays that would clutter the output. This is
-  helpful when reading data from an existing SOFA object.
-* ``sofa.list_dimensions`` prints the dimensions of the data inside the SOFA
-  object.
-* ``sofa.get_dimension`` returns the size of a specific dimension.
-
-To list all attributes inside a SOFA object, type the following
-
-.. code-block:: python
-
-    sofa.info("all")
-
-Note that this function can also be used to list only the mandatory or
-optional fields.
-
-You might have noted from ``sofa.info("all")`` that three different kinds of
+You might have noted from the documentation that three different kinds of
 data types can be stored in SOFA files:
 
 * **Attributes:**
@@ -80,24 +67,20 @@ data types can be stored in SOFA files:
     Variables of type *string* store strings and can be entered as strings,
     lists of string, or numpy string arrays.
 
-Lets take a look and list all information for only SOFA variable:
+The data can be mandatory, optional, and read only and must have a shape
+(dimension in SOFA language) according to the underlying convention. Read on
+for more information.
 
-.. code-block:: python
+To get a quick insight into SOFA objects use
 
-    sofa.info("Data_IR")
-    >>> SimpleFreeFieldHRIR 1.0 (SOFA version 2.0)
-    >>> -------------------------------------------
-    >>> Data_IR
-    >>>     type: double
-    >>>     mandatory: True
-    >>>     read only: False
-    >>>     default: [0, 0]
-    >>>     shape: MRN
-    >>>     comment: None
+* ``sofa.inspect`` prints the data stored in a SOFA object or at least gives
+  the shape in case of large arrays that would clutter the output. This is
+  helpful when reading data from an existing SOFA object.
+* ``sofa.list_dimensions`` prints the dimensions of the data inside the SOFA
+  object.
+* ``sofa.get_dimension`` returns the size of a specific dimension.
 
-`Data_IR` is a mandatory double variable of shape `MRN` in which the actual
-HRIRs are stored. The letters M, R, and N are the `dimensions` of the SOFA
-object. They can be seen via
+For the *SimpleFreeFieldHRIR* SOFA object we have the following dimensions
 
 .. code-block:: python
 
@@ -110,7 +93,7 @@ object. They can be seen via
     >>> I = 1 single dimension, fixed
     >>> S = 0 maximum string length
 
-For the `SimpleFreeFieldHRIR` convention, `M` denotes the number of source
+In this case, `M` denotes the number of source
 positions for which HRIRs are available, `R` is the number of ears - which is
 two - and `N` gives the lengths of the HRIRs in samples. `S` is zero, because
 the convention does not have any string variables. `C` is always three, because
@@ -118,9 +101,9 @@ coordinates are either given by x, y, and z values or by their azimuth,
 elevation and radius in degree.
 
 It is important to be aware of the dimensions and enter data as determined by
-the `shape` printed by ``sofa.info()``. SOFA sets the `dimensions`
+the convention. SOFA sets the `dimensions`
 implicitly. This means the dimensions are derived from the data itself, as
-indicated by the output of :code:`sofa.list_dimensions` above (set by...). In
+indicated by the output of :code:`sofa.list_dimensions` above (*set by...*). In
 some cases, variables can have different shapes. An example for this is the
 `ReceiverPosition` which can be of shape RCI or RCM. To get a dimension as a
 variable use
@@ -148,7 +131,7 @@ and want to quickly inspect it. You could use
 
 Note that the above does not show the entire information for the sake of
 brevity. This will most likely give you a better idea of the data then
-``sofa.info`` and ``sofa.list_dimensions``.
+looking at the definition of the convention or calling ``sofa.list_dimensions``.
 
 Adding data to SOFA objects
 ===========================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,15 @@ Documentation
    sofar.Sofa
    sofar.functions
 
+
+SOFA conventions
+================
+
+.. toctree::
+   :maxdepth: 1
+
+   resources/conventions
+
 Contributing
 ===============
 

--- a/docs/resources/conventions.py
+++ b/docs/resources/conventions.py
@@ -1,0 +1,151 @@
+import os
+import sys
+import json
+sys.path.insert(0, os.path.abspath(os.path.join('..', '..')))
+
+import sofar as sf  # noqa
+
+base_dir = os.path.dirname(__file__)
+
+# get conventions (paths, names, version) and upgrade rules -------------------
+paths = sf.utils._get_conventions('path')
+names_versions = sf.utils._get_conventions('name_version')
+
+# using Sofa()._verification_rules() does not work on readthedocs
+upgrade_rules = os.path.join(
+    os.path.dirname(paths[0]), '..', 'rules', 'upgrade.json')
+with open(upgrade_rules) as file:
+    upgrade_rules = json.load(file)
+
+# write general information ---------------------------------------------------
+docs = (
+    '.. _conventions_introduction:\n\n'
+    'Introduction\n============\n\n'
+    'SOFA conventions specify what data and metadata must be stored in a SOFA '
+    'file. Different conventions can be used to store different types of data,'
+    'e.g., head-related impulse responses or musical instrument directivities.'
+    'It is advised to always use the conventions that is most specific for the'
+    'data.\n\n'
+    'In the following, SOFA conventions are described in tables with the '
+    'information\n\n'
+    '* **Name:** The Name of the data. The prefix *GLOBAL* denotes global '
+    'attribute, i.e., attributes that pertain the entire data set. Underscores'
+    ' denote attributes that are data specific. E.g., *SourcePosition_Units* '
+    'denotes the *Units* of the data *SourcePosition*.\n'
+    '* **Type:** The Type of the data.\n\n'
+    '  * **Attribute:** A verbose description given by a string\n'
+    '  * **Double:** A numeric array of data\n'
+    '  * **String:** A string array of data\n\n'
+    '* **Default:** The default value\n'
+    '* **Dimensions:** The dimensions of the data. Lower case letters denote '
+    'the data that sets the dimension.\n\n'
+    '  * **E:** Number of emitters\n'
+    '  * **R:** Number of receivers\n'
+    '  * **M:** Number of measurements\n'
+    '  * **N:** Number of samples or frequency bins of the data\n'
+    '  * **C:** Number of coordinates (always 3)\n'
+    '  * **I:** Unity dimentions (always 1)\n'
+    '  * **S:** Lengths of the longest string contained in the data '
+    '(detected automatically)\n\n'
+    '* **Flags:**\n\n'
+    '  * **r:** read only data. Data can be written if flag is missing.\n'
+    '  * **m:** mandatory data. Data is optional if flag is missing\n\n')
+
+# write table of content ------------------------------------------------------
+docs += '.. _conventions:\n\nConventions\n===========\n\n'
+for path, name_version in zip(paths, names_versions):
+    name, version = name_version
+
+    label = f'{name} v{version}'
+    if 'deprecated' in path:
+        label += ' (deprecated)'
+    reference = f'{name}_{version}'
+
+    docs += f'* :ref:`{label} <{reference}>`\n'
+
+# write conventions -----------------------------------------------------------
+docs += '\nCurrent\n=======\n\n'
+
+# loop conventions
+deprecated = False
+for path, name_version in zip(paths, names_versions):
+    name, version = name_version
+
+    # read convention from json file
+    with open(path, 'r') as file:
+        convention = json.load(file)
+
+    # write section title
+    if 'deprecated' in path and not deprecated:
+        docs += 'Deprecated\n==========\n\n'
+        deprecated = True
+
+    # write convention name, version
+    docs += f'.. _{name}_{version}:\n\n'
+    docs += f'**{name} v{version}**\n\n'
+
+    # name new convention if current convention is deprecated
+    if deprecated:
+        if name not in upgrade_rules:
+            upgrade_to = None
+        for upgrade in upgrade_rules[name]['from_to']:
+            if version in upgrade[0]:
+                upgrade_to = upgrade[1]
+                references = [f':ref:`{u} <{u}>`' for u in upgrade_to]
+                ':ref:`{label} <{reference}>`'
+                docs += ('This convention is deprecated. '
+                         f'Use {", ".join(references)} instead.\n\n')
+
+    # name purpose of the convention
+    docs += f'{convention["GLOBAL:SOFAConventions"]["comment"]}\n\n'
+
+    # write header
+    docs += (
+        '.. list-table::\n'
+        '   :widths: 20 50 25 30 100\n'
+        '   :header-rows: 1\n\n'
+        '   * - Name (Type)\n'
+        '     - Default\n'
+        '     - Dim.\n'
+        '     - Flags\n'
+        '     - Comment\n')
+
+    # loop entries
+    for key, value in convention.items():
+
+        if value["dimensions"] is None:
+            dimensions = ""
+        else:
+            dimensions = value["dimensions"]
+
+        if value["flags"] is None:
+            flags = ""
+        elif len(value["flags"]) > 1:
+            flags = f'{value["flags"][0]}, {value["flags"][1]}'
+        else:
+            flags = value["flags"]
+
+        if key == "GLOBAL:SOFAConventions":
+            value["comment"] = ""
+
+        if value["type"] == 'attribute':
+            type_str = 'attr.'
+        elif value["type"] == 'double':
+            type_str = 'doub.'
+        else:
+            type_str = 'str.'
+
+        docs += (
+            f'   * - {key.replace(":", "_").replace(".", "_")} '
+            f'(*{value["type"]}*)\n'
+            f'     - {value["default"]}\n'
+            f'     - {dimensions}\n'
+            f'     - {flags}\n'
+            f'     - {value["comment"]}\n')
+
+    docs += '\n:ref:`back to top <conventions>`\n\n'
+
+# write docs to rst file ------------------------------------------------------
+docs_file = os.path.join(base_dir, 'conventions.rst')
+with open(docs_file, 'w') as file:
+    file.writelines(docs)

--- a/docs/resources/conventions.rst
+++ b/docs/resources/conventions.rst
@@ -1,0 +1,6581 @@
+.. _conventions_introduction:
+
+Introduction
+============
+
+SOFA conventions specify what data and metadata must be stored in a SOFA file. Different conventions can be used to store different types of data,e.g., head-related impulse responses or musical instrument directivities.It is advised to always use the conventions that is most specific for thedata.
+
+In the following, SOFA conventions are described in tables with the information
+
+* **Name:** The Name of the data. The prefix *GLOBAL* denotes global attribute, i.e., attributes that pertain the entire data set. Underscores denote attributes that are data specific. E.g., *SourcePosition_Units* denotes the *Units* of the data *SourcePosition*.
+* **Type:** The Type of the data.
+
+  * **Attribute:** A verbose description given by a string
+  * **Double:** A numeric array of data
+  * **String:** A string array of data
+
+* **Default:** The default value
+* **Dimensions:** The dimensions of the data. Lower case letters denote the data that sets the dimension.
+
+  * **E:** Number of emitters
+  * **R:** Number of receivers
+  * **M:** Number of measurements
+  * **N:** Number of samples or frequency bins of the data
+  * **C:** Number of coordinates (always 3)
+  * **I:** Unity dimentions (always 1)
+  * **S:** Lengths of the longest string contained in the data (detected automatically)
+
+* **Flags:**
+
+  * **r:** read only data. Data can be written if flag is missing.
+  * **m:** mandatory data. Data is optional if flag is missing
+
+.. _conventions:
+
+Conventions
+===========
+
+* :ref:`FreeFieldDirectivityTF v1.0 <FreeFieldDirectivityTF_1.0>`
+* :ref:`FreeFieldDirectivityTF v1.1 <FreeFieldDirectivityTF_1.1>`
+* :ref:`FreeFieldHRIR v1.0 <FreeFieldHRIR_1.0>`
+* :ref:`FreeFieldHRTF v1.0 <FreeFieldHRTF_1.0>`
+* :ref:`GeneralFIR-E v2.0 <GeneralFIR-E_2.0>`
+* :ref:`GeneralFIR v1.0 <GeneralFIR_1.0>`
+* :ref:`GeneralSOS v1.0 <GeneralSOS_1.0>`
+* :ref:`GeneralTF-E v1.0 <GeneralTF-E_1.0>`
+* :ref:`GeneralTF v1.0 <GeneralTF_1.0>`
+* :ref:`GeneralTF v2.0 <GeneralTF_2.0>`
+* :ref:`SimpleFreeFieldHRIR v1.0 <SimpleFreeFieldHRIR_1.0>`
+* :ref:`SimpleFreeFieldHRSOS v1.0 <SimpleFreeFieldHRSOS_1.0>`
+* :ref:`SimpleFreeFieldHRTF v1.0 <SimpleFreeFieldHRTF_1.0>`
+* :ref:`SimpleFreeFieldSOS v1.0 <SimpleFreeFieldSOS_1.0>`
+* :ref:`SimpleHeadphoneIR v1.0 <SimpleHeadphoneIR_1.0>`
+* :ref:`SingleRoomMIMOSRIR v1.0 <SingleRoomMIMOSRIR_1.0>`
+* :ref:`SingleRoomSRIR v1.0 <SingleRoomSRIR_1.0>`
+* :ref:`GeneralFIRE v1.0 (deprecated) <GeneralFIRE_1.0>`
+* :ref:`MultiSpeakerBRIR v0.3 (deprecated) <MultiSpeakerBRIR_0.3>`
+* :ref:`SimpleFreeFieldHRIR v0.4 (deprecated) <SimpleFreeFieldHRIR_0.4>`
+* :ref:`SimpleFreeFieldTF v0.4 (deprecated) <SimpleFreeFieldTF_0.4>`
+* :ref:`SimpleFreeFieldTF v1.0 (deprecated) <SimpleFreeFieldTF_1.0>`
+* :ref:`SimpleHeadphoneIR v0.1 (deprecated) <SimpleHeadphoneIR_0.1>`
+* :ref:`SimpleHeadphoneIR v0.2 (deprecated) <SimpleHeadphoneIR_0.2>`
+* :ref:`SingleRoomDRIR v0.2 (deprecated) <SingleRoomDRIR_0.2>`
+* :ref:`SingleRoomDRIR v0.3 (deprecated) <SingleRoomDRIR_0.3>`
+
+Current
+=======
+
+.. _FreeFieldDirectivityTF_1.0:
+
+**FreeFieldDirectivityTF v1.0**
+
+This conventions stores directivities of acoustic sources (instruments, loudspeakers, singers, talkers, etc) in the frequency domain for multiple musical notes in free field.
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - FreeFieldDirectivityTF
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - TF
+     - 
+     - r, m
+     - We store frequency-dependent data here
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - The room information can be arbitrary, but the spatial setup assumes free field.
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - Name of the database. Used for classification of the data
+   * - GLOBAL_Musician (*attribute*)
+     - 
+     - 
+     - 
+     - Narrative description of the musician such as position, behavior, or personal data if not data-protected, e.g., 'Christiane Schmidt sitting on the chair', or 'artificial excitation by R2D2'.
+   * - GLOBAL_Description (*attribute*)
+     - 
+     - 
+     - 
+     - Narrative description of a measurement. For musical instruments/singers, the note (C1, D1, etc) or the dynamic (pp., ff., etc), or the string played, the playing style (pizzicato, legato, etc.), or the type of excitation (e.g., hit location of a cymbal). For loudspeakers, the system and driver units.
+   * - GLOBAL_SourceType (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the acoustic source, e.g., 'Violin', 'Female singer', or '2-way loudspeaker'
+   * - GLOBAL_SourceManufacturer (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the manufacturer of the source, e.g., 'Stradivari, Lady Blunt, 1721' or 'LoudspeakerCompany'
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Position of the microphone array during the measurements.
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - Orientation of the microphone array
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Up vector of the microphone array
+   * - ReceiverPosition (*double*)
+     - [0, 0, 1]
+     - IC, RC, RCM
+     - m
+     - Positions of the microphones during the measurements (relative to the Listener)
+   * - ReceiverPosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Position of the acoustic source (instrument)
+   * - SourcePosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition_Reference (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the spatial reference of the source position, e.g., for the trumpet, 'The bell'. Mandatory in order to provide a reference across different instruments
+   * - SourceView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - Orientation of the acoustic source (instrument)
+   * - SourceView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourceView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourceView_Reference (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the spatial reference of the source view, e.g., for the trumpet, 'Viewing direction of the bell'. Mandatory in order to provide a reference across different instruments
+   * - SourceUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Up vector of the acoustic source (instrument)
+   * - SourceUp_Reference (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the spatial reference of the source up, e.g., for the trumpet, 'Along the keys, keys up'. Mandatory in order to provide a reference across different instruments
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - A more detailed structure of the Source. In a simple settings, a single Emitter is considered that is collocated with the source.
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - EmitterDescription (*string*)
+     - ['']
+     - IS, MS
+     - 
+     - A more detailed structure of the source. In a simple setting, a single Emitter is considered that is collocated with the source. In a more complicated setting, this may be the strings of a violin or the units of a loudspeaker.
+   * - MIDINote (*double*)
+     - 0
+     - I, M
+     - 
+     - Defines the note played by the source during the measurement. The note is specified a MIDI note by the [https://www.midi.org/specifications-old/item/the-midi-1-0-specification MIDI specifications, version 1.0]. Not mandatory, but recommended for tonal instruments.
+   * - Description (*string*)
+     - ['']
+     - MS
+     - 
+     - This variable is used when the description varies with M.
+   * - SourceTuningFrequency (*double*)
+     - 440
+     - I, M
+     - 
+     - Frequency (in hertz) to which a musical instrument is tuned to corresponding to the note A4 (MIDINote=69). Recommended for tonal instruments.
+   * - N (*double*)
+     - 0
+     - N
+     - m
+     - Frequency values
+   * - N_LongName (*attribute*)
+     - frequency
+     - 
+     - m
+     - 
+   * - N_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - Units used for N
+   * - Data_Real (*double*)
+     - 0
+     - mrn
+     - m
+     - Real part of the complex spectrum. The default value 0 indicates that all data fields are initialized with zero values.
+   * - Data_Imag (*double*)
+     - 0
+     - MRN
+     - m
+     - Imaginary part of the complex spectrum
+
+:ref:`back to top <conventions>`
+
+.. _FreeFieldDirectivityTF_1.1:
+
+**FreeFieldDirectivityTF v1.1**
+
+This conventions stores directivities of acoustic sources (instruments, loudspeakers, singers, talkers, etc) in the frequency domain for multiple musical notes in free field.
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - FreeFieldDirectivityTF
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - TF
+     - 
+     - r, m
+     - We store frequency-dependent data here
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - The room information can be arbitrary, but the spatial setup assumes free field.
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - Name of the database. Used for classification of the data
+   * - GLOBAL_Musician (*attribute*)
+     - 
+     - 
+     - 
+     - Narrative description of the musician such as position, behavior, or personal data if not data-protected, e.g., 'Christiane Schmidt sitting on the chair', or 'artificial excitation by R2D2'.
+   * - GLOBAL_Description (*attribute*)
+     - 
+     - 
+     - 
+     - Narrative description of a measurement. For musical instruments/singers, the note (C1, D1, etc) or the dynamic (pp., ff., etc), or the string played, the playing style (pizzicato, legato, etc.), or the type of excitation (e.g., hit location of a cymbal). For loudspeakers, the system and driver units.
+   * - GLOBAL_SourceType (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the acoustic source, e.g., 'Violin', 'Female singer', or '2-way loudspeaker'
+   * - GLOBAL_SourceManufacturer (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the manufacturer of the source, e.g., 'Stradivari, Lady Blunt, 1721' or 'LoudspeakerCompany'
+   * - GLOBAL_EmitterDescription (*attribute*)
+     - 
+     - 
+     - 
+     - A more detailed structure of the source. In a simple setting, a single Emitter is considered that is collocated with the source. In a more complicated setting, this may be the strings of a violin or the units of a loudspeaker.
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Position of the microphone array during the measurements.
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - Orientation of the microphone array
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Up vector of the microphone array
+   * - ReceiverPosition (*double*)
+     - [0, 0, 0]
+     - IC, RC, RCM
+     - m
+     - Positions of the microphones during the measurements (relative to the Listener)
+   * - ReceiverPosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - Type of the coordinate system used.
+   * - ReceiverPosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - Units of the coordinates.
+   * - SourcePosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Position of the acoustic source (instrument)
+   * - SourcePosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition_Reference (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the spatial reference of the source position, e.g., 'The bell' for a trumpet or 'On the front plate between the low- and mid/high-frequency unit' for a loudspeaker. Mandatory in order to provide a reference across different sources.
+   * - SourceView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - View vector for the orientation.
+   * - SourceView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourceView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourceView_Reference (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the spatial reference of the source view, e.g., 'Viewing direction of the bell' for a trumpet or 'Perpendicular to the front plate' for a loudspeaker. Mandatory in order to provide a reference across different sources.
+   * - SourceUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Up vector of the acoustic source (instrument)
+   * - SourceUp_Reference (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the spatial reference of the source up, e.g., 'Along the keys, keys up' for a trumpet or 'Perpendicular to the top plate' for a loudspeaker. Mandatory in order to provide a reference across different sources.
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eC, eCM
+     - m
+     - Position. In a simple settings, a single emitter is considered that is collocated with the source.
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - EmitterDescriptions (*string*)
+     - ['']
+     - MS, ES, MES
+     - 
+     - A more detailed description of the Emitters. For example, this may be the strings of a violin or the units of a loudspeaker.
+   * - MIDINote (*double*)
+     - 0
+     - I, M
+     - 
+     - Defines the note played by the source during the measurement. The note is specified a MIDI note by the [https://www.midi.org/specifications-old/item/the-midi-1-0-specification MIDI specifications, version 1.0]. Not mandatory, but recommended for tonal instruments.
+   * - Description (*string*)
+     - ['']
+     - MS
+     - 
+     - This variable is used when the description varies with M.
+   * - SourceTuningFrequency (*double*)
+     - 440
+     - I, M
+     - 
+     - Frequency (in hertz) to which a musical instrument is tuned to corresponding to the note A4 (MIDINote=69). Recommended for tonal instruments.
+   * - N (*double*)
+     - 0
+     - N
+     - m
+     - Frequency values
+   * - N_LongName (*attribute*)
+     - frequency
+     - 
+     - m
+     - narrative name of N
+   * - N_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - Units used for N
+   * - Data_Real (*double*)
+     - 0
+     - mrn
+     - m
+     - Real part of the complex spectrum. The default value 0 indicates that all data fields are initialized with zero values.
+   * - Data_Imag (*double*)
+     - 0
+     - MRN
+     - m
+     - Imaginary part of the complex spectrum
+
+:ref:`back to top <conventions>`
+
+.. _FreeFieldHRIR_1.0:
+
+**FreeFieldHRIR v1.0**
+
+An extension of SimpleFreeFieldHRIR in order to consider more complex data sets described in spatially continuous representation. Each HRTF direction corresponds to an emitter, and a consistent measurement for a single listener and all directions is described by a set of the emitter positions surrounding the listener.
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - FreeFieldHRIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - FIR-E
+     - 
+     - r, m
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_ListenerShortName (*attribute*)
+     - 
+     - 
+     - m
+     - Short name of the listener (as for example the subject ID).
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - Name of the database to which these data belong
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - RCI, RCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Source position is assumed to be the ListenerPosition in order to reflect Emitters surrounding the Listener
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - IC, ECI, ECM
+     - m
+     - Radius in 'spherical harmonics', Position in 'cartesian' and 'spherical'
+   * - EmitterPosition_Type (*attribute*)
+     - spherical harmonics
+     - 
+     - m
+     - Can be 'spherical harmonics', 'cartesian', or 'spherical'
+   * - EmitterPosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - Data_IR (*double*)
+     - [0, 0]
+     - mrne
+     - m
+     - 
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I, M
+     - m
+     - 
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+   * - Data_Delay (*double*)
+     - [0, 0]
+     - IRI, MRI, MRE
+     - m
+     - Additional delay of each IR (in samples)
+
+:ref:`back to top <conventions>`
+
+.. _FreeFieldHRTF_1.0:
+
+**FreeFieldHRTF v1.0**
+
+This conventions is for HRTFs created under conditions where room information is irrelevant and stored as SH coefficients
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - FreeFieldHRTF
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - TF-E
+     - 
+     - r, m
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_ListenerShortName (*attribute*)
+     - 
+     - 
+     - m
+     - ID of the subject from the database
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - Name of the database to which these data belong
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - RCI, RCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Source position is assumed to be the ListenerPosition in order to reflect Emitters surrounding the Listener
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - IC, ECI, ECM
+     - m
+     - Radius in 'spherical harmonics', Position in 'cartesian' and 'spherical'
+   * - EmitterPosition_Type (*attribute*)
+     - spherical harmonics
+     - 
+     - m
+     - Can be 'spherical harmonics', 'cartesian', or 'spherical'
+   * - EmitterPosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - N (*double*)
+     - 0
+     - N
+     - m
+     - 
+   * - N_LongName (*attribute*)
+     - frequency
+     - 
+     - m
+     - narrative name of N
+   * - N_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+   * - Data_Real (*double*)
+     - [0, 0]
+     - mrne
+     - m
+     - 
+   * - Data_Imag (*double*)
+     - [0, 0]
+     - MRNE
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+
+.. _GeneralFIR-E_2.0:
+
+**GeneralFIR-E v2.0**
+
+This conventions stores IRs for general purposes, i.e., only the mandatory, SOFA general metadata are pre-defined
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - GeneralFIR-E
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 2.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - FIR-E
+     - 
+     - r, m
+     - We use FIR datatype which in addition depends on Emitters (E)
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - The room information can be arbitrary
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [0, 0, 0]
+     - IC, RC, RCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - IC, EC, ECM
+     - m
+     - Each speaker is represented as an emitter. Use EmitterPosition to represent the position of a particular speaker. Size of EmitterPosition determines E
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - Data_IR (*double*)
+     - 0
+     - mrne
+     - m
+     - Impulse responses
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I, M
+     - m
+     - Sampling rate of the samples in Data.IR and Data.Delay
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - Unit of the sampling rate
+   * - Data_Delay (*double*)
+     - 0
+     - IRE, MRE
+     - m
+     - Additional delay of each IR (in samples)
+
+:ref:`back to top <conventions>`
+
+.. _GeneralFIR_1.0:
+
+**GeneralFIR v1.0**
+
+This conventions stores IRs for general purposes, i.e., only the mandatory, SOFA general metadata are pre-defined
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - GeneralFIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - FIR
+     - 
+     - r, m
+     - We store IRs here
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - The room information can be arbitrary
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [0, 0, 0]
+     - IC, RC, RCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - In order to store different directions/positions around the listener, SourcePosition is assumed to vary
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eCI, eCM
+     - m
+     - 
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - 
+     - 
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - 
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - 
+     - 
+   * - Data_IR (*double*)
+     - 0
+     - mrn
+     - m
+     - Impulse responses
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I, M
+     - m
+     - Sampling rate of the samples in Data.IR and Data.Delay
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - Unit of the sampling rate
+   * - Data_Delay (*double*)
+     - 0
+     - IR, MR
+     - m
+     - Additional delay of each IR (in samples)
+
+:ref:`back to top <conventions>`
+
+.. _GeneralSOS_1.0:
+
+**GeneralSOS v1.0**
+
+This conventions follows GeneralFIR but the data is stored as second-order section (SOS) coefficients.
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - GeneralSOS
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - SOS
+     - 
+     - r, m
+     - Filters described as second-order section (SOS) coefficients
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - The room information can be arbitrary
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - 
+     - 
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - 
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - 
+     - 
+   * - ReceiverPosition (*double*)
+     - [0, 0, 0]
+     - IC, RC, RCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - In order to store different directions/positions around the listener, SourcePosition is assumed to vary
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eCI, eCM
+     - m
+     - 
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - Data_SOS (*double*)
+     - [[[0, 0, 0, 1, 0, 0]]]
+     - mrn
+     - m
+     - Filter coefficients as SOS coefficients.
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I, M
+     - m
+     - Sampling rate of the coefficients in Data.SOS and the delay in Data.Delay
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - Unit of the sampling rate
+   * - Data_Delay (*double*)
+     - 0
+     - IR, MR
+     - m
+     - Broadband delay (in samples resulting from SamplingRate)
+
+:ref:`back to top <conventions>`
+
+.. _GeneralTF-E_1.0:
+
+**GeneralTF-E v1.0**
+
+This conventions stores TFs depending in the Emiiter for general purposes, i.e., only the mandatory, SOFA general metadata are pre-defined. This convention is based on GeneralTF
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - GeneralTF-E
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - TF-E
+     - 
+     - r, m
+     - We store frequency-dependent data depending on the emitter here
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - The room information can be arbitrary
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [0, 0, 0]
+     - IC, RC, RCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - In order to store different directions/positions around the listener, SourcePosition is assumed to vary
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - IC, EC, ECM
+     - m
+     - 
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - N (*double*)
+     - 0
+     - N
+     - m
+     - Frequency values
+   * - N_LongName (*attribute*)
+     - frequency
+     - 
+     - m
+     - narrative name of N
+   * - N_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - Unit of the values given in N
+   * - Data_Real (*double*)
+     - 0
+     - mrne
+     - m
+     - The real part of the complex spectrum
+   * - Data_Imag (*double*)
+     - 0
+     - MRNE
+     - m
+     - The imaginary part of the complex spectrum
+
+:ref:`back to top <conventions>`
+
+.. _GeneralTF_1.0:
+
+**GeneralTF v1.0**
+
+This conventions stores TFs for general purposes, i.e., only the mandatory, SOFA general metadata are pre-defined. This convention is based on GeneralFIR.
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - GeneralTF
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - TF
+     - 
+     - r, m
+     - We store frequency-dependent data here
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - The room information can be arbitrary
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [0, 0, 0]
+     - rCI, rCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - In order to store different directions/positions around the listener, SourcePosition is assumed to vary
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eCI, eCM
+     - m
+     - 
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - N (*double*)
+     - 0
+     - N
+     - m
+     - Frequency values
+   * - N_LongName (*attribute*)
+     - frequency
+     - 
+     - m
+     - narrative name of N
+   * - N_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - Unit of the values given in N
+   * - Data_Real (*double*)
+     - 0
+     - mRn
+     - m
+     - The real part of the complex spectrum
+   * - Data_Imag (*double*)
+     - 0
+     - MRN
+     - m
+     - The imaginary part of the complex spectrum
+
+:ref:`back to top <conventions>`
+
+.. _GeneralTF_2.0:
+
+**GeneralTF v2.0**
+
+This conventions stores TFs for general purposes, i.e., only the mandatory, SOFA general metadata are pre-defined. This convention is based on GeneralFIR.
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - GeneralTF
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 2.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - TF
+     - 
+     - r, m
+     - We store frequency-dependent data here
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - The room information can be arbitrary
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [0, 0, 0]
+     - IC, RC, RCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - In order to store different directions/positions around the listener, SourcePosition is assumed to vary
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eC, eCM
+     - m
+     - 
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - N (*double*)
+     - 0
+     - N
+     - m
+     - Frequency values
+   * - N_LongName (*attribute*)
+     - frequency
+     - 
+     - m
+     - narrative name of N
+   * - N_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - Unit of the values given in N
+   * - Data_Real (*double*)
+     - 0
+     - mrn
+     - m
+     - The real part of the complex spectrum
+   * - Data_Imag (*double*)
+     - 0
+     - MRN
+     - m
+     - The imaginary part of the complex spectrum
+
+:ref:`back to top <conventions>`
+
+.. _SimpleFreeFieldHRIR_1.0:
+
+**SimpleFreeFieldHRIR v1.0**
+
+This convention set is for HRIRs recorded under free-field conditions or other IRs created under conditions where room information is irrelevant
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - SimpleFreeFieldHRIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - FIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - name of the database to which these data belong
+   * - GLOBAL_ListenerShortName (*attribute*)
+     - 
+     - 
+     - m
+     - ID of the subject from the database
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - rCI, rCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Source position is assumed to vary for different directions/positions around the listener
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eCI, eCM
+     - m
+     - 
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourceUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - 
+     - 
+   * - SourceView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - 
+     - 
+   * - SourceView_Type (*attribute*)
+     - cartesian
+     - 
+     - 
+     - 
+   * - SourceView_Units (*attribute*)
+     - metre
+     - 
+     - 
+     - 
+   * - Data_IR (*double*)
+     - [0, 0]
+     - mRn
+     - m
+     - 
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I, M
+     - m
+     - 
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+   * - Data_Delay (*double*)
+     - [0, 0]
+     - IR, MR
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+
+.. _SimpleFreeFieldHRSOS_1.0:
+
+**SimpleFreeFieldHRSOS v1.0**
+
+This convention set follows SimpleFreeFieldHRIR but the data is stored as second-order section (SOS) coefficients.
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - SimpleFreeFieldHRSOS
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - SOS
+     - 
+     - r, m
+     - Filters described as second-order section (SOS) coefficients
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - name of the database to which these data belong
+   * - GLOBAL_ListenerShortName (*attribute*)
+     - 
+     - 
+     - m
+     - ID of the subject from the database
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - rCI, rCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Source position is assumed to vary for different directions/positions around the listener
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eCI, eCM
+     - m
+     - 
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - Data_SOS (*double*)
+     - [[[0, 0, 0, 1, 0, 0], [0, 0, 0, 1, 0, 0]]]
+     - mRn
+     - m
+     - Filter coefficients as SOS coefficients.
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I, M
+     - m
+     - Sampling rate of the coefficients in Data.SOS and the delay in Data.Delay
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+   * - Data_Delay (*double*)
+     - [0, 0]
+     - IR, MR
+     - m
+     - Broadband delay (in samples resulting from SamplingRate)
+
+:ref:`back to top <conventions>`
+
+.. _SimpleFreeFieldHRTF_1.0:
+
+**SimpleFreeFieldHRTF v1.0**
+
+This conventions is for HRTFs created under conditions where room information is irrelevant
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - SimpleFreeFieldHRTF
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - TF
+     - 
+     - r, m
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_ListenerShortName (*attribute*)
+     - 
+     - 
+     - m
+     - ID of the subject from the database
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - name of the database to which these data belong
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - rCI, rCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Source position is assumed to vary for different directions/positions around the listener
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eCI, eCM
+     - m
+     - 
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - N (*double*)
+     - 0
+     - N
+     - m
+     - 
+   * - N_LongName (*attribute*)
+     - frequency
+     - 
+     - m
+     - narrative name of N
+   * - N_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+   * - Data_Real (*double*)
+     - [0, 0]
+     - mRn
+     - m
+     - 
+   * - Data_Imag (*double*)
+     - [0, 0]
+     - MRN
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+
+.. _SimpleFreeFieldSOS_1.0:
+
+**SimpleFreeFieldSOS v1.0**
+
+This convention set follows SimpleFreeFieldHRIR but the data is stored as second-order section (SOS) coefficients.
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - SimpleFreeFieldSOS
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - SOS
+     - 
+     - r, m
+     - Filters described as second-order section (SOS) coefficients
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - name of the database to which these data belong
+   * - GLOBAL_ListenerShortName (*attribute*)
+     - 
+     - 
+     - m
+     - ID of the subject from the database
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - rCI, rCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Source position is assumed to vary for different directions/positions around the listener
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eCI, eCM
+     - m
+     - 
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - Data_SOS (*double*)
+     - [[[0, 0, 0, 1, 0, 0], [0, 0, 0, 1, 0, 0]]]
+     - mRn
+     - m
+     - Filter coefficients as SOS coefficients.
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I
+     - m
+     - Sampling rate of the coefficients in Data.SOS and the delay in Data.Delay
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+   * - Data_Delay (*double*)
+     - [0, 0]
+     - IR, MR
+     - m
+     - Broadband delay (in samples resulting from SamplingRate)
+
+:ref:`back to top <conventions>`
+
+.. _SimpleHeadphoneIR_1.0:
+
+**SimpleHeadphoneIR v1.0**
+
+Conventions for IRs with a 1-to-1 correspondence between emitter and receiver. The main application for this convention is to store headphone IRs recorded for each emitter and each ear.
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - SimpleHeadphoneIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - FIR
+     - 
+     - r, m
+     - We will store IRs here
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - Room type is not relevant here
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - Correspondence to a database
+   * - GLOBAL_ListenerShortName (*attribute*)
+     - 
+     - 
+     - m
+     - Correspondence to a subject from the database
+   * - GLOBAL_ListenerDescription (*attribute*)
+     - 
+     - 
+     - 
+     - Narrative description of the listener (or mannequin)
+   * - GLOBAL_SourceDescription (*attribute*)
+     - 
+     - 
+     - 
+     - Narrative description of the headphones
+   * - GLOBAL_SourceManufacturer (*attribute*)
+     - 
+     - 
+     - 
+     - Name of the headphones manufacturer
+   * - GLOBAL_SourceModel (*attribute*)
+     - 
+     - 
+     - 
+     - Name of the headphone model. Must uniquely describe the headphones of the manufacturer
+   * - GLOBAL_SourceURI (*attribute*)
+     - 
+     - 
+     - 
+     - URI of the headphone specifications
+   * - GLOBAL_ReceiverDescription (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the microphones
+   * - GLOBAL_EmitterDescription (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the headphone drivers
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - rCI, rCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Default: Headphones are located at the position of the listener
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - eCI, eCM
+     - m
+     - Default: Reflects the correspondence of each emitter to each receiver
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourceManufacturer (*string*)
+     - ['']
+     - MS
+     - 
+     - Optional M-dependent version of the attribute SourceManufucturer
+   * - SourceModel (*string*)
+     - ['']
+     - MS
+     - 
+     - Optional M-dependent version of the attribute SourceModel
+   * - ReceiverDescriptions (*string*)
+     - ['']
+     - MS
+     - 
+     - R-dependent version of the attribute ReceiverDescription
+   * - EmitterDescriptions (*string*)
+     - ['']
+     - MS
+     - 
+     - E-dependent version of the attribute EmitterDescription
+   * - MeasurementDate (*double*)
+     - 0
+     - M
+     - 
+     - Optional M-dependent date and time of the measurement
+   * - Data_IR (*double*)
+     - [0, 0]
+     - mRn
+     - m
+     - 
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I, M
+     - m
+     - 
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+   * - Data_Delay (*double*)
+     - [0, 0]
+     - IR, MR
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+
+.. _SingleRoomMIMOSRIR_1.0:
+
+**SingleRoomMIMOSRIR v1.0**
+
+Single-room multiple-input multiple-output spatial room impulse responses, depending on Emitters
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - SingleRoomMIMOSRIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - FIR-E
+     - 
+     - r, m
+     - Shall be FIR-E
+   * - GLOBAL_RoomType (*attribute*)
+     - shoebox
+     - 
+     - m
+     - Shall be 'shoebox' or 'dae'
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - Name of the database. Used for classification of the data.
+   * - GLOBAL_RoomShortName (*attribute*)
+     - 
+     - 
+     - 
+     - Short name of the Room
+   * - GLOBAL_RoomDescription (*attribute*)
+     - 
+     - 
+     - 
+     - Informal verbal description of the room
+   * - GLOBAL_RoomLocation (*attribute*)
+     - 
+     - 
+     - 
+     - Location of the room
+   * - GLOBAL_RoomGeometry (*attribute*)
+     - 
+     - 
+     - 
+     - URI to a file describing the room geometry.
+   * - GLOBAL_ListenerShortName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ListenerDescription (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ReceiverShortName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ReceiverDescription (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_SourceShortName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_SourceDescription (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_EmitterShortName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_EmitterDescription (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - RoomTemperature (*double*)
+     - 0
+     - I, M
+     - 
+     - Temperature during measurements, given in Kelvin.
+   * - RoomTemperature_Units (*attribute*)
+     - kelvin
+     - 
+     - 
+     - Units of the room temperature
+   * - RoomVolume (*double*)
+     - 0
+     - I, MI
+     - 
+     - Volume of the room
+   * - RoomVolume_Units (*attribute*)
+     - cubic metre
+     - 
+     - 
+     - Units of the room volume
+   * - RoomCornerA (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - 
+     - 
+   * - RoomCornerB (*double*)
+     - [1, 2, 3]
+     - IC, MC
+     - 
+     - 
+   * - RoomCorners (*double*)
+     - 0
+     - II
+     - 
+     - The value of this attribute is to be ignored. It only exist to for RoomCorners:Type and RoomCorners:Units
+   * - RoomCorners_Type (*attribute*)
+     - cartesian
+     - 
+     - 
+     - 
+   * - RoomCorners_Units (*attribute*)
+     - metre
+     - 
+     - 
+     - 
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverDescriptions (*string*)
+     - ['']
+     - RS, RSM
+     - 
+     - R-dependent version of the attribute ReceiverDescription
+   * - ReceiverPosition (*double*)
+     - [0, 0, 0]
+     - IC, RCI, RCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - Can be of any type enabling both spatially discrete and spatially continuous representations.
+   * - ReceiverPosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - ReceiverView (*double*)
+     - [1, 0, 0]
+     - RCI, RCM
+     - 
+     - 
+   * - ReceiverUp (*double*)
+     - [0, 0, 1]
+     - RCI, RCM
+     - 
+     - 
+   * - ReceiverView_Type (*attribute*)
+     - cartesian
+     - 
+     - 
+     - 
+   * - ReceiverView_Units (*attribute*)
+     - metre
+     - 
+     - 
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - MC
+     - m
+     - 
+   * - SourcePosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourceView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - SourceUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - SourceView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourceView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - EmitterDescriptions (*string*)
+     - ['']
+     - ES, ESM
+     - 
+     - E-dependent version of the attribute EmitterDescription
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - IC, ECI, ECM
+     - m
+     - Can be of any type enabling both spatially discrete and spatially continuous representations.
+   * - EmitterPosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterView (*double*)
+     - [1, 0, 0]
+     - ECI, ECM
+     - 
+     - 
+   * - EmitterUp (*double*)
+     - [0, 0, 1]
+     - ECI, ECM
+     - 
+     - 
+   * - EmitterView_Type (*attribute*)
+     - cartesian
+     - 
+     - 
+     - 
+   * - EmitterView_Units (*attribute*)
+     - metre
+     - 
+     - 
+     - 
+   * - MeasurementDate (*double*)
+     - 0
+     - M
+     - 
+     - Optional M-dependent date and time of the measurement.
+   * - Data_IR (*double*)
+     - 0
+     - mrne
+     - m
+     - Impulse responses
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I, M
+     - m
+     - Sampling rate of the samples in Data.IR and Data.Delay
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - Unit of the sampling rate
+   * - Data_Delay (*double*)
+     - 0
+     - IRI, MRI, MRE
+     - m
+     - Additional delay of each IR (in samples)
+
+:ref:`back to top <conventions>`
+
+.. _SingleRoomSRIR_1.0:
+
+**SingleRoomSRIR v1.0**
+
+For measuring SRIRs in a single room with a single excitation source (e.g., a loudspeaker) and a listener containing an arbitrary number of omnidirectional receivers (e.g., a microphone array).
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - SingleRoomSRIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - FIR
+     - 
+     - r, m
+     - Shall be FIR
+   * - GLOBAL_RoomType (*attribute*)
+     - shoebox
+     - 
+     - m
+     - Shall be 'shoebox' or 'dae'
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - Name of the database. Used for classification of the data.
+   * - GLOBAL_RoomShortName (*attribute*)
+     - 
+     - 
+     - 
+     - Short name of the Room
+   * - GLOBAL_RoomDescription (*attribute*)
+     - 
+     - 
+     - 
+     - Informal verbal description of the room
+   * - GLOBAL_RoomLocation (*attribute*)
+     - 
+     - 
+     - 
+     - Location of the room
+   * - GLOBAL_RoomGeometry (*attribute*)
+     - 
+     - 
+     - 
+     - URI to a file describing the room geometry.
+   * - GLOBAL_ListenerShortName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ListenerDescription (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ReceiverShortName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ReceiverDescription (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_SourceShortName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_SourceDescription (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_EmitterShortName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_EmitterDescription (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - RoomTemperature (*double*)
+     - 0
+     - I, M
+     - 
+     - Temperature during measurements, given in Kelvin.
+   * - RoomTemperature_Units (*attribute*)
+     - kelvin
+     - 
+     - 
+     - Units of the room temperature.
+   * - RoomVolume (*double*)
+     - 0
+     - I, M
+     - 
+     - Volume of the room.
+   * - RoomVolume_Units (*attribute*)
+     - cubic metre
+     - 
+     - 
+     - Units of the room volume.
+   * - RoomCornerA (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - 
+     - 
+   * - RoomCornerB (*double*)
+     - [1, 2, 3]
+     - IC, MC
+     - 
+     - 
+   * - RoomCorners (*double*)
+     - 0
+     - II
+     - 
+     - The value of this attribute is to be ignored. It only exist to for RoomCorners:Type and RoomCorners:Units
+   * - RoomCorners_Type (*attribute*)
+     - cartesian
+     - 
+     - 
+     - 
+   * - RoomCorners_Units (*attribute*)
+     - metre
+     - 
+     - 
+     - 
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverDescriptions (*string*)
+     - ['']
+     - RS, RSM
+     - 
+     - R-dependent version of the attribute ReceiverDescription
+   * - ReceiverPosition (*double*)
+     - [0, 0, 0]
+     - IC, RCI, RCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - Can be of any type enabling both spatially discrete and spatially continuous representations.
+   * - ReceiverPosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - ReceiverView (*double*)
+     - [1, 0, 0]
+     - RCI, RCM
+     - 
+     - 
+   * - ReceiverUp (*double*)
+     - [0, 0, 1]
+     - RCI, RCM
+     - 
+     - 
+   * - ReceiverView_Type (*attribute*)
+     - cartesian
+     - 
+     - 
+     - 
+   * - ReceiverView_Units (*attribute*)
+     - metre
+     - 
+     - 
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - MC
+     - m
+     - 
+   * - SourcePosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourceView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - SourceUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - SourceView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourceView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - EmitterDescriptions (*string*)
+     - ['']
+     - ES, ESM
+     - 
+     - E-dependent version of the attribute EmitterDescription
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eCI, eCM
+     - m
+     - 
+   * - EmitterPosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - Shall be 'cartesian' or 'spherical', restricting to spatially discrete emitters.
+   * - EmitterPosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterView (*double*)
+     - [1, 0, 0]
+     - ECI, ECM
+     - 
+     - 
+   * - EmitterUp (*double*)
+     - [0, 0, 1]
+     - ECI, ECM
+     - 
+     - 
+   * - EmitterView_Type (*attribute*)
+     - cartesian
+     - 
+     - 
+     - Shall be 'cartesian' or 'spherical', restricting to spatially discrete emitters.
+   * - EmitterView_Units (*attribute*)
+     - metre
+     - 
+     - 
+     - 
+   * - MeasurementDate (*double*)
+     - 0
+     - M
+     - 
+     - Optional M-dependent date and time of the measurement
+   * - Data_IR (*double*)
+     - 0
+     - mrn
+     - m
+     - Impulse responses
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I, M
+     - m
+     - Sampling rate of the samples in Data.IR and Data.Delay
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - Unit of the sampling rate
+   * - Data_Delay (*double*)
+     - 0
+     - IR, MR
+     - m
+     - Additional delay of each IR (in samples)
+
+:ref:`back to top <conventions>`
+
+Deprecated
+==========
+
+.. _GeneralFIRE_1.0:
+
+**GeneralFIRE v1.0**
+
+This convention is deprecated. Use :ref:`GeneralFIR-E_2.0 <GeneralFIR-E_2.0>` instead.
+
+This conventions stores IRs for general purposes, i.e., only the mandatory, SOFA general metadata are pre-defined
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - GeneralFIRE
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - FIRE
+     - 
+     - r, m
+     - We use FIR datatype which in addition depends on Emitters (E)
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - The room information can be arbitrary
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [0, 0, 0]
+     - rCI, rCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eCI, eCM
+     - m
+     - Each speaker is represented as an emitter. Use EmitterPosition to represent the position of a particular speaker. Size of EmitterPosition determines E
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - Data_IR (*double*)
+     - 0
+     - mREn
+     - m
+     - Impulse responses
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I
+     - m
+     - Sampling rate of the samples in Data.IR and Data.Delay
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - Unit of the sampling rate
+   * - Data_Delay (*double*)
+     - 0
+     - IRE, MRE
+     - m
+     - Additional delay of each IR (in samples)
+
+:ref:`back to top <conventions>`
+
+.. _MultiSpeakerBRIR_0.3:
+
+**MultiSpeakerBRIR v0.3**
+
+This convention is deprecated. Use :ref:`SingleRoomMIMOSRIR_1.0 <SingleRoomMIMOSRIR_1.0>` instead.
+
+This convention is for BRIRs recorded in reverberant conditions from multiple loudspeaker sources at a number of listener orientations.
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - MultiSpeakerBRIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 0.3
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - FIRE
+     - 
+     - r, m
+     - We use FIR datatype which in addition depends on Emitters (E)
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - reverberant
+     - 
+     - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - name of the database to which these data belong
+   * - GLOBAL_ListenerShortName (*attribute*)
+     - 
+     - 
+     - m
+     - ID of the subject from the database
+   * - GLOBAL_RoomDescription (*attribute*)
+     - 
+     - 
+     - 
+     - narrative description of the room
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - rCI, rCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eCI, eCM
+     - m
+     - Each speaker is represented as an emitter. Use EmitterPosition to represent the position of a particular speaker. Size of EmitterPosition determines E
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - EmitterUp (*double*)
+     - [0, 0, 1]
+     - ECI, ECM
+     - 
+     - When EmitterUp provided, EmitterView must be provided as well
+   * - EmitterView (*double*)
+     - [1, 0, 0]
+     - ECI, ECM
+     - 
+     - When EmitterView provided, EmitterUp must be provided as well
+   * - EmitterView_Type (*attribute*)
+     - cartesian
+     - 
+     - 
+     - 
+   * - EmitterView_Units (*attribute*)
+     - metre
+     - 
+     - 
+     - 
+   * - Data_IR (*double*)
+     - [1, 1]
+     - mREn
+     - m
+     - 
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I
+     - m
+     - 
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+   * - Data_Delay (*double*)
+     - [0, 0]
+     - IRE, MRE
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+
+.. _SimpleFreeFieldHRIR_0.4:
+
+**SimpleFreeFieldHRIR v0.4**
+
+This convention is deprecated. Use :ref:`SimpleFreeFieldHRIR_1.0 <SimpleFreeFieldHRIR_1.0>` instead.
+
+This convention set is for HRIRs recorded under free-field conditions or other IRs created under conditions where room information is irrelevant
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - SimpleFreeFieldHRIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 0.4
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - FIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - name of the database to which these data belong
+   * - GLOBAL_ListenerShortName (*attribute*)
+     - 
+     - 
+     - m
+     - ID of the subject from the database
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - meter
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - rCI, rCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - meter
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Source position is assumed to vary for different directions/positions around the listener
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, meter
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eCI, eCM
+     - m
+     - 
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - meter
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - meter
+     - 
+     - m
+     - 
+   * - Data_IR (*double*)
+     - [1, 1]
+     - mRn
+     - m
+     - 
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I
+     - m
+     - 
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+   * - Data_Delay (*double*)
+     - [0, 0]
+     - IR, MR
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+
+.. _SimpleFreeFieldTF_0.4:
+
+**SimpleFreeFieldTF v0.4**
+
+This convention is deprecated. Use :ref:`SimpleFreeFieldHRTF_1.0 <SimpleFreeFieldHRTF_1.0>` instead.
+
+This conventions is for TFs created under conditions where room information is irrelevant
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - SimpleFreeFieldTF
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 0.4
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - TF
+     - 
+     - r, m
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_ListenerShortName (*attribute*)
+     - 
+     - 
+     - m
+     - ID of the subject from the database
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - name of the database to which these data belong
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - meter
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - rCI, rCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - meter
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Source position is assumed to vary for different directions/positions around the listener
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, meter
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eCI, eCM
+     - m
+     - 
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - meter
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - meter
+     - 
+     - m
+     - 
+   * - N (*double*)
+     - 0
+     - N
+     - m
+     - 
+   * - N_LongName (*attribute*)
+     - frequency
+     - 
+     - 
+     - 
+   * - N_Units (*attribute*)
+     - hertz
+     - 
+     - 
+     - 
+   * - Data_Real (*double*)
+     - [1, 1]
+     - mRn
+     - m
+     - 
+   * - Data_Imag (*double*)
+     - [0, 0]
+     - MRN
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+
+.. _SimpleFreeFieldTF_1.0:
+
+**SimpleFreeFieldTF v1.0**
+
+This convention is deprecated. Use :ref:`SimpleFreeFieldHRTF_1.0 <SimpleFreeFieldHRTF_1.0>` instead.
+
+This conventions is for TFs created under conditions where room information is irrelevant
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - SimpleFreeFieldTF
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - TF
+     - 
+     - r, m
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_ListenerShortName (*attribute*)
+     - 
+     - 
+     - m
+     - ID of the subject from the database
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - name of the database to which these data belong
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - rCI, rCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Source position is assumed to vary for different directions/positions around the listener
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eCI, eCM
+     - m
+     - 
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - N (*double*)
+     - 0
+     - N
+     - m
+     - 
+   * - N_LongName (*attribute*)
+     - frequency
+     - 
+     - 
+     - 
+   * - N_Units (*attribute*)
+     - hertz
+     - 
+     - 
+     - 
+   * - Data_Real (*double*)
+     - [0, 0]
+     - mRn
+     - m
+     - 
+   * - Data_Imag (*double*)
+     - [0, 0]
+     - MRN
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+
+.. _SimpleHeadphoneIR_0.1:
+
+**SimpleHeadphoneIR v0.1**
+
+This convention is deprecated. Use :ref:`SimpleHeadphoneIR_1.0 <SimpleHeadphoneIR_1.0>` instead.
+
+Conventions for IRs with a 1-to-1 correspondence between emitter and receiver. The main application for this convention is to store headphone IRs recorded for each emitter and each ear.
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - SimpleHeadphoneIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 0.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - FIR
+     - 
+     - r, m
+     - We will store IRs here
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - Room type is not relevant here
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - Correspondence to a database
+   * - GLOBAL_ListenerShortName (*attribute*)
+     - 
+     - 
+     - m
+     - Correspondence to a subject from the database
+   * - GLOBAL_ListenerDescription (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the listener (or mannequin)
+   * - GLOBAL_SourceDescription (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the headphones
+   * - GLOBAL_SourceManufacturer (*attribute*)
+     - 
+     - 
+     - m
+     - Name of the headphones manufacturer
+   * - GLOBAL_SourceModel (*attribute*)
+     - 
+     - 
+     - m
+     - Name of the headphone model. Must uniquely describe the headphones of the manufacturer
+   * - GLOBAL_SourceURI (*attribute*)
+     - 
+     - 
+     - m
+     - URI of the headphone specifications
+   * - GLOBAL_ReceiverDescription (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the microphones
+   * - GLOBAL_EmitterDescription (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the headphone drivers
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - meter
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - rCI, rCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - meter
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Default: Headphones are located at the position of the listener
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, meter
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - eCI, eCM
+     - m
+     - Default: Reflects the correspondence of each emitter to each receiver
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - meter
+     - 
+     - m
+     - 
+   * - SourceManufacturer (*string*)
+     - ['']
+     - MS
+     - 
+     - Optional M-dependent version of the attribute SourceManufucturer
+   * - SourceModel (*string*)
+     - ['']
+     - MS
+     - 
+     - Optional M-dependent version of the attribute SourceModel
+   * - ReceiverDescription (*string*)
+     - ['']
+     - MS
+     - 
+     - Optional M-dependent version of the attribute ReceiverDescription
+   * - EmitterDescription (*string*)
+     - ['']
+     - MS
+     - 
+     - Optional M-dependent version of the attribute EmitterDescription
+   * - MeasurementDate (*double*)
+     - 0
+     - M
+     - 
+     - Optional M-dependent date and time of the measurement
+   * - Data_IR (*double*)
+     - [1, 1]
+     - mRn
+     - m
+     - 
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I
+     - m
+     - 
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+   * - Data_Delay (*double*)
+     - [0, 0]
+     - IR, MR
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+
+.. _SimpleHeadphoneIR_0.2:
+
+**SimpleHeadphoneIR v0.2**
+
+This convention is deprecated. Use :ref:`SimpleHeadphoneIR_1.0 <SimpleHeadphoneIR_1.0>` instead.
+
+Conventions for IRs with a 1-to-1 correspondence between emitter and receiver. The main application for this convention is to store headphone IRs recorded for each emitter and each ear.
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - SimpleHeadphoneIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 0.2
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - FIR
+     - 
+     - r, m
+     - We will store IRs here
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - Room type is not relevant here
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - Correspondence to a database
+   * - GLOBAL_ListenerShortName (*attribute*)
+     - 
+     - 
+     - m
+     - Correspondence to a subject from the database
+   * - GLOBAL_ListenerDescription (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the listener (or mannequin)
+   * - GLOBAL_SourceDescription (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the headphones
+   * - GLOBAL_SourceManufacturer (*attribute*)
+     - 
+     - 
+     - m
+     - Name of the headphones manufacturer
+   * - GLOBAL_SourceModel (*attribute*)
+     - 
+     - 
+     - m
+     - Name of the headphone model. Must uniquely describe the headphones of the manufacturer
+   * - GLOBAL_SourceURI (*attribute*)
+     - 
+     - 
+     - m
+     - URI of the headphone specifications
+   * - GLOBAL_ReceiverDescription (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the microphones
+   * - GLOBAL_EmitterDescription (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the headphone drivers
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - rCI, rCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Default: Headphones are located at the position of the listener
+   * - SourcePosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - eCI, eCM
+     - m
+     - Default: Reflects the correspondence of each emitter to each receiver
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourceManufacturer (*string*)
+     - ['']
+     - MS
+     - 
+     - Optional M-dependent version of the attribute SourceManufucturer
+   * - SourceModel (*string*)
+     - ['']
+     - MS
+     - 
+     - Optional M-dependent version of the attribute SourceModel
+   * - ReceiverDescription (*string*)
+     - ['']
+     - MS
+     - 
+     - Optional M-dependent version of the attribute ReceiverDescription
+   * - EmitterDescription (*string*)
+     - ['']
+     - MS
+     - 
+     - Optional M-dependent version of the attribute EmitterDescription
+   * - MeasurementDate (*double*)
+     - 0
+     - M
+     - 
+     - Optional M-dependent date and time of the measurement
+   * - Data_IR (*double*)
+     - [0, 0]
+     - mRn
+     - m
+     - 
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I
+     - m
+     - 
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+   * - Data_Delay (*double*)
+     - [0, 0]
+     - IR, MR
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+
+.. _SingleRoomDRIR_0.2:
+
+**SingleRoomDRIR v0.2**
+
+This convention is deprecated. Use :ref:`SingleRoomSRIR_1.0 <SingleRoomSRIR_1.0>` instead.
+
+This convention stores arbitrary number of receivers while providing an information about the room. The main application is to store DRIRs for a single room.
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - SingleRoomDRIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 0.2
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - FIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - reverberant
+     - 
+     - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_RoomDescription (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - meter
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [0, 0, 0]
+     - rCI, rCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - meter
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - SourcePosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - meter
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eCI, eCM
+     - m
+     - 
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - meter
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourceUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - SourceView (*double*)
+     - [-1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - SourceView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourceView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - Data_IR (*double*)
+     - [1]
+     - mRn
+     - m
+     - 
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I
+     - m
+     - 
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+   * - Data_Delay (*double*)
+     - [0]
+     - IR, MR
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+
+.. _SingleRoomDRIR_0.3:
+
+**SingleRoomDRIR v0.3**
+
+This convention is deprecated. Use :ref:`SingleRoomSRIR_1.0 <SingleRoomSRIR_1.0>` instead.
+
+This convention stores arbitrary number of receivers while providing an information about the room. The main application is to store DRIRs for a single room.
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - SingleRoomDRIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 0.3
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - FIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - reverberant
+     - 
+     - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_RoomDescription (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [0, 0, 0]
+     - RCI, RCM
+     - m
+     - 
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - SourcePosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eCI, eCM
+     - m
+     - 
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourceUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - 
+   * - SourceView (*double*)
+     - [-1, 0, 0]
+     - IC, MC
+     - m
+     - 
+   * - SourceView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourceView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - Data_IR (*double*)
+     - [0]
+     - mrn
+     - m
+     - 
+   * - Data_SamplingRate (*double*)
+     - 48000
+     - I
+     - m
+     - 
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+   * - Data_Delay (*double*)
+     - [0]
+     - IR, MR
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10'
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11'
     ],
     description="Maybe the most complete python package for SOFA files so far",
     install_requires=requirements,

--- a/sofar/__init__.py
+++ b/sofar/__init__.py
@@ -8,7 +8,7 @@ __version__ = '1.0.0'
 
 from .sofa import Sofa
 
-from .io import read_sofa, write_sofa
+from .io import read_sofa, read_sofa_as_netcdf, write_sofa
 
 from .utils import (list_conventions,
                     equals,
@@ -21,6 +21,7 @@ __all__ = ['Sofa',
            'update_conventions',
            'list_conventions',
            'read_sofa',
+           'read_sofa_as_netcdf',
            'write_sofa',
            'equals',
            'version']

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -3,6 +3,7 @@ import os
 import numpy as np
 from netCDF4 import Dataset, chartostring, stringtochar
 import warnings
+import pathlib
 from packaging.version import parse
 import sofar as sf
 from .utils import _verify_convention_and_version, _atleast_nd
@@ -107,8 +108,7 @@ def read_sofa_as_netcdf(filename):
 def _read_netcdf(filename, verify, verbose, mode):
 
     # check the filename
-    if mode == "sofa" and not filename.endswith('.sofa'):
-        raise ValueError("Filename must end with .sofa")
+    filename = pathlib.Path(filename).with_suffix('.sofa')
     if not os.path.isfile(filename):
         raise ValueError(f"{filename} does not exist")
 
@@ -255,11 +255,10 @@ def _write_sofa(filename: str, sofa: sf.Sofa, compression=4, verify=True):
     write_sofa for documentation.
     """
 
-    if verify:
-        # check the filename
-        if not filename.endswith('.sofa'):
-            raise ValueError("Filename must end with .sofa")
+    # check the filename
+    filename = pathlib.Path(filename).with_suffix('.sofa')
 
+    if verify:
         # check if the latest version is used for writing and warn otherwise
         # if case required for writing SOFA test data that violates the
         # conventions

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 from netCDF4 import Dataset, chartostring, stringtochar
 import warnings
-import packaging
+from packaging.version import parse
 import sofar as sf
 from .utils import _verify_convention_and_version, _atleast_nd
 
@@ -18,8 +18,7 @@ def read_sofa(filename, verify=True, verbose=True):
     Parameters
     ----------
     filename : str
-        The filename. '.sofa' is appended to the filename, if it is not
-        explicitly given.
+        The full path to the sofa data.
     verify : bool, optional
         Verify and update the SOFA object by calling :py:func:`~Sofa.verify`.
         This helps to find potential errors in the default values and is thus
@@ -32,7 +31,7 @@ def read_sofa(filename, verify=True, verbose=True):
     Returns
     -------
     sofa : Sofa
-        The SOFA object filled with the default values of the convention.
+        Object containing the data from `filename`.
 
     Notes
     -----
@@ -52,8 +51,63 @@ def read_sofa(filename, verify=True, verbose=True):
        will be a scalar inside SOFA objects after reading from disk.
     """
 
+    return _read_netcdf(filename, verify, verbose, mode="sofa")
+
+
+def read_sofa_as_netcdf(filename):
+    """
+    Read corrupted SOFA data from disk.
+
+    .. note::
+        `read_sofa_as_netcdf` is intended to read and fix corrupted SOFA data
+        that could not be read by :py:func:`~read_sofa`. The recommend workflow
+        is
+
+        - Try to read the data with `read_sofa` and ``verify=True``
+        - If this fails, try the above with ``verify=False``
+        - If this fails, use `read_sofa_as_netcdf`
+
+        The SOFA object  returned by `read_sofa_as_netcdf` may not work
+        correctly before the issues with the data were fixed, i.e., before the
+        data are in agreement with the SOFA standard AES-69.
+
+    Numeric data is returned as floats or numpy float arrays unless they have
+    missing data, in which case they are returned as numpy masked arrays.
+
+    Parameters
+    ----------
+    filename : str
+        The full path to the NetCDF data.
+
+    Returns
+    -------
+    sofa : Sofa
+        Object containing the data from `filename`.
+
+    Notes
+    -----
+
+    1. Missing dimensions are appended when writing the SOFA object to disk.
+       E.g., if ``sofa.Data_IR`` is of shape (1, 2) it is written as an array
+       of shape (1, 2, 1) because the SOFA standard AES69-2020 defines it as a
+       three dimensional array with the dimensions (`M: measurements`,
+       `R: receivers`, `N: samples`)
+    2. When reading data from a SOFA file, array data is always returned as
+       numpy arrays and singleton trailing dimensions are discarded (numpy
+       default). I.e., ``sofa.Data_IR`` will again be an array of shape (1, 2)
+       after writing and reading to and from disk.
+    3. One dimensional arrays with only one element will be converted to scalar
+       values. E.g. ``sofa.Data_SamplingRate`` is stored as an array of shape
+       (1, ) inside SOFA files (according to the SOFA standard AES69-2020) but
+       will be a scalar inside SOFA objects after reading from disk.
+    """
+    return _read_netcdf(filename, False, False, mode="netcdf")
+
+
+def _read_netcdf(filename, verify, verbose, mode):
+
     # check the filename
-    if not filename.endswith('.sofa'):
+    if mode == "sofa" and not filename.endswith('.sofa'):
         raise ValueError("Filename must end with .sofa")
     if not os.path.isfile(filename):
         raise ValueError(f"{filename} does not exist")
@@ -68,28 +122,24 @@ def read_sofa(filename, verify=True, verbose=True):
     # open new NETCDF4 file for reading
     with Dataset(filename, "r", format="NETCDF4") as file:
 
-        # get convention name and version
-        convention = getattr(file, "SOFAConventions")
-        all_attr.append("GLOBAL_SOFAConventions")
-        version_in = getattr(file, "SOFAConventionsVersion")
-        all_attr.append("GLOBAL_SOFAConventionsVersion")
+        if mode == "sofa":
+            # get convention name and version
+            convention = getattr(file, "SOFAConventions")
+            version = getattr(file, "SOFAConventionsVersion")
 
-        # check if convention and version exist
-        version_out = _verify_convention_and_version(
-            version_in, version_in, convention)
+            # check if convention and version exist
+            _verify_convention_and_version(version, convention)
 
-        # get SOFA object with default values
-        sofa = sf.Sofa(convention, version=version_out, verify=verify)
+            # get SOFA object with default values
+            sofa = sf.Sofa(convention, version=version, verify=verify)
+        else:
+            sofa = sf.Sofa(None)
 
         # allow writing read only attributes
-        sofa._protected = False
+        sofa.protected = False
 
         # load global attributes
         for attr in file.ncattrs():
-
-            if attr in ["SOFAConventionsVersion", "SOFAConventions"]:
-                # convention and version were already set above
-                continue
 
             value = getattr(file, attr)
             all_attr.append(f"GLOBAL_{attr}")
@@ -98,7 +148,7 @@ def read_sofa(filename, verify=True, verbose=True):
                 sofa._add_custom_api_entry(
                     f"GLOBAL_{attr}", value, None, None, "attribute")
                 custom.append(f"GLOBAL_{attr}")
-                sofa._protected = False
+                sofa.protected = False
             else:
                 setattr(sofa, f"GLOBAL_{attr}", value)
 
@@ -117,7 +167,7 @@ def read_sofa(filename, verify=True, verbose=True):
                 sofa._add_custom_api_entry(var.replace(".", "_"), value, None,
                                            dimensions, dtype)
                 custom.append(var.replace(".", "_"))
-                sofa._protected = False
+                sofa.protected = False
 
             # load variable attributes
             for attr in [a for a in file[var].ncattrs() if a not in skip]:
@@ -130,7 +180,7 @@ def read_sofa(filename, verify=True, verbose=True):
                         var.replace(".", "_") + "_" + attr, value, None,
                         None, "attribute")
                     custom.append(var.replace(".", "_") + "_" + attr)
-                    sofa._protected = False
+                    sofa.protected = False
                 else:
                     setattr(sofa, var.replace(".", "_") + "_" + attr, value)
 
@@ -142,7 +192,7 @@ def read_sofa(filename, verify=True, verbose=True):
             delattr(sofa, attr)
 
     # do not allow writing read only attributes any more
-    sofa._protected = True
+    sofa.protected = True
 
     # notice about custom entries
     if custom and verbose:
@@ -205,21 +255,25 @@ def _write_sofa(filename: str, sofa: sf.Sofa, compression=4, verify=True):
     write_sofa for documentation.
     """
 
-    # check the filename
-    if not filename.endswith('.sofa'):
-        raise ValueError("Filename must end with .sofa")
+    if verify:
+        # check the filename
+        if not filename.endswith('.sofa'):
+            raise ValueError("Filename must end with .sofa")
 
-    # check if the latest version is used for writing and warn otherwise
-    # if case required for writing SOFA test data that violates the conventions
-    if sofa.GLOBAL_SOFAConventions != "invalid-value":
-        latest = sf.Sofa(sofa.GLOBAL_SOFAConventions)
-        latest = latest.GLOBAL_SOFAConventionsVersion
-        current = sofa.GLOBAL_SOFAConventionsVersion
+        # check if the latest version is used for writing and warn otherwise
+        # if case required for writing SOFA test data that violates the
+        # conventions
+        if sofa.GLOBAL_SOFAConventions != "invalid-value":
+            latest = sf.Sofa(sofa.GLOBAL_SOFAConventions)
+            latest = latest.GLOBAL_SOFAConventionsVersion
+            current = sofa.GLOBAL_SOFAConventionsVersion
 
-        if packaging.version.parse(current) < packaging.version.parse(latest):
-            warnings.warn(("Writing SOFA object with outdated Convention "
-                           f"version {current}. Use version='latest' to write "
-                           f"data with version {latest}."))
+            if parse(current) < parse(latest):
+                warnings.warn((
+                    "Writing SOFA object with outdated Convention "
+                    f"version {current}. It is recommend to upgrade "
+                    " data with Sofa.upgrade_convention() before "
+                    "writing to disk if possible."))
 
     # setting the netCDF compression parameter
     use_zlib = compression != 0

--- a/sofar/sofa.py
+++ b/sofar/sofa.py
@@ -295,6 +295,13 @@ class Sofa():
                 attribute will be printed.
         """
 
+        # warn for upcoming deprecation
+        warnings.warn((
+            'Sofa.info() will be deprecated in sofar 1.3.0 The conventions are'
+            ' now documented at '
+            'https://sofar.readthedocs.io/en/stable/resources/conventions.html'),  # noqa
+            UserWarning)
+
         # update the private attribute `_convention` to make sure the required
         # meta data is in place
         if not hasattr(self, "_convention"):
@@ -519,7 +526,7 @@ class Sofa():
 
         dimensions : str
             The shape of the new entry as a string. See
-            ``self.info('dimensions')``.
+            :py:func:`~Sofa.list_dimensions`.
 
         Examples
         --------
@@ -574,9 +581,10 @@ class Sofa():
         """
         Delete variable or attribute from SOFA object.
 
-        Note that mandatory data can not be deleted. Call
-        :py:func:`Sofa.info("optional") <sofar.sofar.Sofa.info>` to list all
-        optional variables and attributes.
+        Note that mandatory data can not be deleted. Check the
+        `sofar documentation
+        <https://sofar.readthedocs.io/en/stable/resources/conventions.html>`_
+        for a complete list of optional variables and attributes.
 
         Parameters
         ----------

--- a/sofar/update_conventions.py
+++ b/sofar/update_conventions.py
@@ -333,7 +333,7 @@ def _convention_csv2dict(file: str):
     return convention
 
 
-def _check_congruency(save_dir=None):
+def _check_congruency(save_dir=None, branch="master"):
     """
     SOFA conventions are stored in two different places - is this a good idea?
     They should be identical, but let's find out.
@@ -348,7 +348,7 @@ def _check_congruency(save_dir=None):
 
     urls = ["https://www.sofaconventions.org/conventions/",
             ("https://raw.githubusercontent.com/sofacoustics/SOFAtoolbox/"
-             "master/SOFAtoolbox/conventions/")]
+             f"{branch}/SOFAtoolbox/conventions/")]
     subdirs = ["sofaconventions", "sofatoolbox"]
 
     # check save_dir

--- a/sofar/update_conventions.py
+++ b/sofar/update_conventions.py
@@ -346,9 +346,14 @@ def _check_congruency(save_dir=None, branch="master"):
         directory to save diverging conventions for further inspections
     """
 
-    urls = ["https://www.sofaconventions.org/conventions/",
-            ("https://raw.githubusercontent.com/sofacoustics/SOFAtoolbox/"
-             f"{branch}/SOFAtoolbox/conventions/")]
+    # urls for checking which conventions exist
+    urls_check = ["https://www.sofaconventions.org/conventions/",
+                  ("https://github.com/sofacoustics/SOFAtoolbox/tree/"
+                   f"{branch}/SOFAtoolbox/conventions/")]
+    # urls for loading the convention files
+    urls_load = ["https://www.sofaconventions.org/conventions/",
+                 ("https://raw.githubusercontent.com/sofacoustics/SOFAtoolbox/"
+                  f"{branch}/SOFAtoolbox/conventions/")]
     subdirs = ["sofaconventions", "sofatoolbox"]
 
     # check save_dir
@@ -359,21 +364,29 @@ def _check_congruency(save_dir=None, branch="master"):
             if not os.path.isdir(os.path.join(save_dir, subdir)):
                 os.makedirs(os.path.join(save_dir, subdir))
 
-    # get file names of conventions from sofaconventions.org and SOFAtoolbox
-    url = urls[0]
+    # get file names of conventions from sofaconventions.org
+    url = urls_check[0]
     page = requests.get(url).text
     soup = BeautifulSoup(page, 'html.parser')
     sofaconventions = [os.path.split(node.get('href'))[1]
                        for node in soup.find_all('a')
                        if node.get('href').endswith(".csv")]
 
-    url = ("https://github.com/sofacoustics/SOFAtoolbox/tree/"
-           "master/SOFAtoolbox/conventions/")
-    page = requests.get(url).text
-    soup = BeautifulSoup(page, 'html.parser')
-    sofatoolbox = [os.path.split(node.get('href'))[1]
-                   for node in soup.find_all('a')
-                   if node.get('href').endswith(".csv")]
+    if not sofaconventions:
+        raise ValueError(f"Did not find any conventions at {url}")
+
+    # get file names of conventions from github
+    url = urls_check[1]
+    page = requests.get(url).json()
+    sofatoolbox = []
+    for content in page["payload"]["tree"]["items"]:
+        if content["contentType"] == "file" and \
+                content["path"].startswith("SOFAtoolbox/conventions") and \
+                content["name"].endswith("csv"):
+            sofatoolbox.append(content["name"])
+
+    if not sofatoolbox:
+        raise ValueError(f"Did not find any conventions at {url}")
 
     # check if lists are identical. Remove items not contained in both lists
     report = ""
@@ -394,7 +407,7 @@ def _check_congruency(save_dir=None, branch="master"):
     for convention in sofaconventions:
 
         # download SOFA convention definitions to package directory
-        data = [requests.get(url + convention) for url in urls]
+        data = [requests.get(url + convention) for url in urls_load]
         # remove trailing tabs and windows style line breaks
         data = [d.content.replace(b"\r\n", b"\n").replace(b"\t\n", b"\n")
                 for d in data]

--- a/sofar/utils.py
+++ b/sofar/utils.py
@@ -2,7 +2,6 @@ import os
 import glob
 import numpy as np
 import numpy.testing as npt
-from packaging.version import parse as version_parse
 import warnings
 import sofar as sf
 
@@ -19,58 +18,39 @@ def version():
             f"SOFA standard {sofa_conventions}")
 
 
-def _verify_convention_and_version(version, version_in, convention):
+def _verify_convention_and_version(version, convention):
     """
-    Verify if convention and version exist and return version
+    Verify if convention and version exist. Raise a Value error if it does not.
 
     Parameters
     ----------
     version : str
-        'latest', 'match', version string (e.g., '1.0')
-    version_in : str
-        The version to be checked against
+        The version to be checked
     convention : str
         The name of the convention to be checked
-
-    Returns
-    -------
-    version_out : str
-        The version to be used depending on `version`, and `version_in`
     """
 
-    # check if the convention exists in sofar
+    # check if the convention exists
     if convention not in _get_conventions("name"):
         raise ValueError(
             f"Convention '{convention}' does not exist")
 
     name_version = _get_conventions("name_version")
 
-    if version == "latest":
-        # get list of versions as floats
-        version_out = [float(versions[1]) for versions in name_version
-                       if versions[0] == convention]
-        # get latest version as string
-        version_out = str(version_out[np.argmax(version_out)])
+    # check which version is wanted
+    version_exists = False
+    for versions in name_version:
+        # check if convention and version match
+        if versions[0] == convention \
+                and str(float(versions[1])) == version:
+            version_exists = True
 
-        if version_parse(version_out) > version_parse(version_in):
-            print(("Updated conventions version from "
-                   f"{version_in} to {version_out}"))
-    else:
-        # check which version is wanted
-        match = version_in if version == "match" else version
-        version_out = None
-        for versions in name_version:
-            # check if convention and version match
-            if versions[0] == convention \
-                    and str(float(versions[1])) == match:
-                version_out = str(float(versions[1]))
-
-        if version_out is None:
-            raise ValueError((
-                f"Version {match} does not exist for convention {convention}. "
-                "Try to access the data with version='latest'"))
-
-    return version_out
+    if not version_exists:
+        raise ValueError((
+            f"{convention} v{version} is not a valid SOFA Convention."
+            "If you are trying to read the data use "
+            "sofar.read_sofa_as_netcdf(). Call sofar.list_conventions() for a "
+            "list of valid Conventions"))
 
 
 def list_conventions():

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,19 @@
+import pytest
+from packaging import version
+import re
+import sofar as sf
+
+
+# deprecate in 1.3.0 ----------------------------------------------------------
+def test_pad_zero_modi():
+    with pytest.warns(
+            UserWarning,
+            match=re.escape('Sofa.info() will be deprecated in sofar 1.3.0')):
+        sofa = sf.Sofa('GeneralTF')
+        sofa.info()
+
+    if version.parse(sf.__version__) >= version.parse('1.3.0'):
+        with pytest.raises(ValueError):
+            # remove Sofa.info() from pyfar 1.3.0!
+            sofa = sf.Sofa('GeneralTF')
+            sofa.info()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -6,6 +6,7 @@ from sofar.utils import (_get_conventions,
 from sofar.io import (_format_value_for_netcdf,
                       _format_value_from_netcdf)
 import os
+import pathlib
 from tempfile import TemporaryDirectory
 import pytest
 from pytest import raises
@@ -14,7 +15,7 @@ import numpy.testing as npt
 from netCDF4 import Dataset
 
 
-def test_read_sofa(capfd):
+def test_read_write_sofa(capfd):
 
     temp_dir = TemporaryDirectory()
     filename = os.path.join(temp_dir.name, "test.sofa")
@@ -23,6 +24,11 @@ def test_read_sofa(capfd):
     # test defaults
     sf.write_sofa(filename, sofa)
     sofa = sf.read_sofa(filename)
+    assert hasattr(sofa, "_api")
+
+    # test with path object
+    sf.write_sofa(pathlib.Path(filename), sofa)
+    sofa = sf.read_sofa(pathlib.Path(filename))
     assert hasattr(sofa, "_api")
 
     # reading without updating API
@@ -64,10 +70,6 @@ def test_read_sofa(capfd):
     # data can be read without updating API
     sf.read_sofa(filename, verify=False)
 
-    # test assertion for wrong filename
-    with raises(ValueError, match="Filename must end with .sofa"):
-        sf.read_sofa('sofa.exe')
-
 
 def test_read_sofa_custom_data():
     """Test if sofa files with custom data are loaded correctly"""
@@ -103,14 +105,6 @@ def test_read_netcdf():
             sf.read_sofa(file)
         sofa_read = sf.read_sofa_as_netcdf(file)
         sf.equals(sofa, sofa_read)
-
-
-def test_write_sofa_assertion():
-    """Test assertion for wrong filename ending"""
-
-    sofa = sf.Sofa("SimpleFreeFieldHRIR")
-    with raises(ValueError, match="Filename must end with .sofa"):
-        sf.write_sofa("sofa.exe", sofa)
 
 
 def test_write_sofa_outdated_version():

--- a/tests/test_sofa.py
+++ b/tests/test_sofa.py
@@ -231,9 +231,9 @@ def test_add_entry():
     assert "Temperature_Units" not in sofa._custom
 
     # test adding missing entry defined in convention
-    sofa._protected = False
+    sofa.protected = False
     delattr(sofa, "ListenerPosition")
-    sofa._protected = True
+    sofa.protected = True
     sofa.add_variable("ListenerPosition", [0, 0, 0], "double", "IC")
     assert "ListenerPosition" not in sofa._custom
 
@@ -273,10 +273,10 @@ def test_add_missing(
     opt = "GLOBAL_History"
 
     # remove data before adding it again
-    sofa._protected = False
+    sofa.protected = False
     sofa.delete(man)
     sofa.delete(opt)
-    sofa._protected = False
+    sofa.protected = False
 
     # add missing data
     sofa.add_missing(mandatory, optional, verbose)
@@ -311,11 +311,6 @@ def test_delete_entry():
     # check if data were removed
     assert not hasattr(sofa, "GLOBAL_History")
     assert not hasattr(sofa, "SourceManufacturer")
-
-
-def test__update_conventions():
-    """Tested in test_sofa_verify.pi::test_version"""
-    pass
 
 
 def test__get_size_and_shape_of_string_var():

--- a/tests/test_sofa_upgrade_conventions.py
+++ b/tests/test_sofa_upgrade_conventions.py
@@ -84,9 +84,18 @@ def test_upgrade_conventions(path, capfd):
     targets = sofa.upgrade_convention()
     out, _ = capfd.readouterr()
 
+    # don't verify conventions that might require user action after
+    if os.path.basename(path) in ["FreeFieldDirectivityTF_1.0.json"]:
+        # FreeFieldDirectivityTF_1.0
+        # - optional dependency GLOBAL_EmitterDescription
+        #   might need to be added
+        verify = False
+    else:
+        verify = True
+
     if targets:
         for target in targets:
-            sofa.upgrade_convention(target)
+            sofa.upgrade_convention(target, verify=verify)
             out, _ = capfd.readouterr()
             assert "Upgrading" in out
     else:

--- a/tests/test_sofa_verify.py
+++ b/tests/test_sofa_verify.py
@@ -115,9 +115,9 @@ def test_case_insensitivity():
 
     # data type (must be case sensitive) --------------------------------------
     sofa = sf.Sofa("SimpleFreeFieldHRIR")
-    sofa._protected = False
+    sofa.protected = False
     sofa.GLOBAL_DataType = "fir"
-    sofa._protected = True
+    sofa.protected = True
     with raises(ValueError, match="GLOBAL_DataType is fir"):
         sofa.verify()
 
@@ -153,9 +153,9 @@ def test_missing_default_attributes(capfd):
 
     # test missing default attribute
     sofa = sf.Sofa("GeneralTF")
-    sofa._protected = False
+    sofa.protected = False
     delattr(sofa, "GLOBAL_Conventions")
-    sofa._protected = True
+    sofa.protected = True
 
     # raises error
     with raises(ValueError, match="Detected missing mandatory data"):
@@ -242,42 +242,42 @@ def test_wrong_name():
 
     # attribute with missing variable
     sofa = sf.Sofa("GeneralTF")
-    sofa._protected = False
+    sofa.protected = False
     sofa.IR_Type = "pressure"
     sofa._custom = {"IR_Type": {"default": None,
                                 "flags": None,
                                 "dimensions": None,
                                 "type": "attribute",
                                 "comment": ""}}
-    sofa._protected = True
+    sofa.protected = True
 
     with raises(ValueError, match="Detected attributes with missing"):
         sofa.verify()
 
     # attribute with no underscore
     sofa = sf.Sofa("GeneralTF")
-    sofa._protected = False
+    sofa.protected = False
     sofa.IRType = "pressure"
     sofa._custom = {"IRType": {"default": None,
                                "flags": None,
                                "dimensions": None,
                                "type": "attribute",
                                "comment": ""}}
-    sofa._protected = True
+    sofa.protected = True
 
     with raises(ValueError, match="Detected attribute names with too many"):
         sofa.verify()
 
     # variable with underscore
     sofa = sf.Sofa("GeneralTF")
-    sofa._protected = False
+    sofa.protected = False
     sofa.IR_Data = 1
     sofa._custom = {"IR_Data": {"default": None,
                                 "flags": None,
                                 "dimensions": "IM",
                                 "type": "double",
                                 "comment": ""}}
-    sofa._protected = True
+    sofa.protected = True
 
     with raises(ValueError, match="Detected variable names with too many"):
         sofa.verify()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -49,7 +49,7 @@ def test__get_conventions(capfd):
         _get_conventions(return_type="None")
 
 
-@pytest.mark.parametrize('branch', ['master', 'develop'])
+@pytest.mark.parametrize('branch', ['master', 'development'])
 def test__congruency(capfd, branch):
     """
     Check if conventions from SOFAToolbox and sofaconventions.org are

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ import pytest
 from pytest import raises
 import numpy as np
 from copy import deepcopy
+import warnings
 
 
 def test_list_conventions(capfd):
@@ -48,15 +49,17 @@ def test__get_conventions(capfd):
         _get_conventions(return_type="None")
 
 
-def test__congruency(capfd):
+@pytest.mark.parametrize('branch', ['master', 'develop'])
+def test__congruency(capfd, branch):
     """
     Check if conventions from SOFAToolbox and sofaconventions.org are
     identical.
     """
     out, _ = capfd.readouterr()
-    _check_congruency()
+    _check_congruency(branch=branch)
     out, _ = capfd.readouterr()
-    assert out == ""
+    if out != "":
+        warnings.warn(out, Warning)
 
 
 def test_update_conventions(capfd):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -160,53 +160,53 @@ def test_equals_global_parameters():
 
     # check different number of keys
     sofa_b = deepcopy(sofa_a)
-    sofa_b._protected = False
+    sofa_b.protected = False
     delattr(sofa_b, "ReceiverPosition")
-    sofa_b._protected = True
+    sofa_b.protected = True
     with pytest.warns(UserWarning, match="not identical: sofa_a has"):
         is_identical = sf.equals(sofa_a, sofa_b)
         assert not is_identical
 
     # check different keys
     sofa_b = deepcopy(sofa_a)
-    sofa_b._protected = False
+    sofa_b.protected = False
     sofa_b.PositionReceiver = sofa_b.ReceiverPosition
     delattr(sofa_b, "ReceiverPosition")
-    sofa_b._protected = True
+    sofa_b.protected = True
     with pytest.warns(UserWarning, match="not identical: sofa_a and sofa_b"):
         is_identical = sf.equals(sofa_a, sofa_b)
         assert not is_identical
 
     # check mismatching data types
     sofa_b = deepcopy(sofa_a)
-    sofa_b._protected = False
+    sofa_b.protected = False
     sofa_b._convention["ReceiverPosition"]["type"] = "int"
-    sofa_b._protected = True
+    sofa_b.protected = True
     with pytest.warns(UserWarning, match="not identical: ReceiverPosition"):
         is_identical = sf.equals(sofa_a, sofa_b)
         assert not is_identical
 
     # check exclude GLOBAL attributes
     sofa_b = deepcopy(sofa_a)
-    sofa_b._protected = False
+    sofa_b.protected = False
     delattr(sofa_b, "GLOBAL_Version")
-    sofa_b._protected = True
+    sofa_b.protected = True
     is_identical = sf.equals(sofa_a, sofa_b, exclude="GLOBAL")
     assert is_identical
 
     # check exclude Date attributes
     sofa_b = deepcopy(sofa_a)
-    sofa_b._protected = False
+    sofa_b.protected = False
     delattr(sofa_b, "GLOBAL_DateModified")
-    sofa_b._protected = True
+    sofa_b.protected = True
     is_identical = sf.equals(sofa_a, sofa_b, exclude="DATE")
     assert is_identical
 
     # check exclude Date attributes
     sofa_b = deepcopy(sofa_a)
-    sofa_b._protected = False
+    sofa_b.protected = False
     delattr(sofa_b, "GLOBAL_DateModified")
-    sofa_b._protected = True
+    sofa_b.protected = True
     is_identical = sf.equals(sofa_a, sofa_b, exclude="ATTR")
     assert is_identical
 
@@ -224,14 +224,14 @@ def test_equals_attribute_values(value_a, value_b, attribute, fails):
 
     # generate SOFA objects (SimpleHeadphoneIR has string variables)
     sofa_a = sf.Sofa("SimpleHeadphoneIR")
-    sofa_a._protected = False
+    sofa_a.protected = False
     sofa_b = deepcopy(sofa_a)
 
     # set parameters
     setattr(sofa_a, attribute, value_a)
-    sofa_a._protected = True
+    sofa_a.protected = True
     setattr(sofa_b, attribute, value_b)
-    sofa_b._protected = True
+    sofa_b.protected = True
 
     # compare
     if fails:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import shutil
 import sofar as sf
 from sofar.utils import _get_conventions
-from sofar.update_conventions import _compile_conventions
+from sofar.update_conventions import _compile_conventions, _check_congruency
 import os
 import json
 from tempfile import TemporaryDirectory
@@ -46,6 +46,17 @@ def test__get_conventions(capfd):
 
     with raises(ValueError, match="return_type None is invalid"):
         _get_conventions(return_type="None")
+
+
+def test__congruency(capfd):
+    """
+    Check if conventions from SOFAToolbox and sofaconventions.org are
+    identical.
+    """
+    out, _ = capfd.readouterr()
+    _check_congruency()
+    out, _ = capfd.readouterr()
+    assert out == ""
 
 
 def test_update_conventions(capfd):


### PR DESCRIPTION
* Deprecate FreeFieldDirectivityTV 1.0 in favor of FreeFieldDirectivityTV 1.1 (according to sofaconventoins.org and AES69-2022)
* Add `sofar.read_sofa_as_netcdf` for reading SOFA files with erroneous data
* Document SOFA conventions on https://sofar.readthedocs.io/en/stable/resources/conventions.html. `Sofa.info()` will this be deprecated in sofar v1.3.0
* `sofar.read_sofa` and `sofar.write_sofa` now accept filenames and path objects
* Add testing for Python 3.11