### PR TITLE
Update conventions

### DIFF
--- a/docs/resources/conventions.py
+++ b/docs/resources/conventions.py
@@ -17,6 +17,11 @@ upgrade_rules = os.path.join(
 with open(upgrade_rules) as file:
     upgrade_rules = json.load(file)
 
+deprecation_rules = os.path.join(
+    os.path.dirname(paths[0]), '..', 'rules', 'deprecations.json')
+with open(deprecation_rules) as file:
+    deprecation_rules = json.load(file)
+
 # write general information ---------------------------------------------------
 docs = (
     '.. _conventions_introduction:\n\n'
@@ -86,15 +91,20 @@ for path, name_version in zip(paths, names_versions):
 
     # name new convention if current convention is deprecated
     if deprecated:
-        if name not in upgrade_rules:
-            upgrade_to = None
-        for upgrade in upgrade_rules[name]['from_to']:
-            if version in upgrade[0]:
-                upgrade_to = upgrade[1]
-                references = [f':ref:`{u} <{u}>`' for u in upgrade_to]
-                ':ref:`{label} <{reference}>`'
-                docs += ('This convention is deprecated. '
-                         f'Use {", ".join(references)} instead.\n\n')
+        # upgrade rules give best feedback
+        if name in upgrade_rules:
+            for upgrade in upgrade_rules[name]['from_to']:
+                if version in upgrade[0]:
+                    upgrade_to = upgrade[1]
+                    references = [f':ref:`{u} <{u}>`' for u in upgrade_to]
+                    ':ref:`{label} <{reference}>`'
+                    docs += ('This convention is deprecated. '
+                             f'Use {", ".join(references)} instead.\n\n')
+        # deprecations are used if no upgrade rules are available
+        elif name in deprecation_rules['GLOBAL:SOFAConventions']:
+            docs += ("This convention is deprecated. Use "
+                     f"{deprecation_rules['GLOBAL:SOFAConventions'][name]} "
+                     "instead.\n\n")
 
     # name purpose of the convention
     docs += f'{convention["GLOBAL:SOFAConventions"]["comment"]}\n\n'

--- a/docs/resources/conventions.rst
+++ b/docs/resources/conventions.rst
@@ -35,7 +35,8 @@ In the following, SOFA conventions are described in tables with the information
 Conventions
 ===========
 
-* :ref:`FreeFieldDirectivityTF v1.0 <FreeFieldDirectivityTF_1.0>`
+* :ref:`AnnotatedEmitterAudio v0.2 <AnnotatedEmitterAudio_0.2>`
+* :ref:`AnnotatedReceiverAudio v0.2 <AnnotatedReceiverAudio_0.2>`
 * :ref:`FreeFieldDirectivityTF v1.1 <FreeFieldDirectivityTF_1.1>`
 * :ref:`FreeFieldHRIR v1.0 <FreeFieldHRIR_1.0>`
 * :ref:`FreeFieldHRTF v1.0 <FreeFieldHRTF_1.0>`
@@ -52,6 +53,9 @@ Conventions
 * :ref:`SimpleHeadphoneIR v1.0 <SimpleHeadphoneIR_1.0>`
 * :ref:`SingleRoomMIMOSRIR v1.0 <SingleRoomMIMOSRIR_1.0>`
 * :ref:`SingleRoomSRIR v1.0 <SingleRoomSRIR_1.0>`
+* :ref:`AnnotatedEmitterAudio v0.1 (deprecated) <AnnotatedEmitterAudio_0.1>`
+* :ref:`AnnotatedReceiverAudio v0.1 (deprecated) <AnnotatedReceiverAudio_0.1>`
+* :ref:`FreeFieldDirectivityTF v1.0 (deprecated) <FreeFieldDirectivityTF_1.0>`
 * :ref:`GeneralFIRE v1.0 (deprecated) <GeneralFIRE_1.0>`
 * :ref:`MultiSpeakerBRIR v0.3 (deprecated) <MultiSpeakerBRIR_0.3>`
 * :ref:`SimpleFreeFieldHRIR v0.4 (deprecated) <SimpleFreeFieldHRIR_0.4>`
@@ -61,15 +65,17 @@ Conventions
 * :ref:`SimpleHeadphoneIR v0.2 (deprecated) <SimpleHeadphoneIR_0.2>`
 * :ref:`SingleRoomDRIR v0.2 (deprecated) <SingleRoomDRIR_0.2>`
 * :ref:`SingleRoomDRIR v0.3 (deprecated) <SingleRoomDRIR_0.3>`
+* :ref:`SingleTrackedAudio v0.1 (deprecated) <SingleTrackedAudio_0.1>`
+* :ref:`SingleTrackedAudio v0.2 (deprecated) <SingleTrackedAudio_0.2>`
 
 Current
 =======
 
-.. _FreeFieldDirectivityTF_1.0:
+.. _AnnotatedEmitterAudio_0.2:
 
-**FreeFieldDirectivityTF v1.0**
+**AnnotatedEmitterAudio v0.2**
 
-This conventions stores directivities of acoustic sources (instruments, loudspeakers, singers, talkers, etc) in the frequency domain for multiple musical notes in free field.
+
 
 .. list-table::
    :widths: 20 50 25 30 100
@@ -91,39 +97,14 @@ This conventions stores directivities of acoustic sources (instruments, loudspea
      - r, m
      - 
    * - GLOBAL_SOFAConventions (*attribute*)
-     - FreeFieldDirectivityTF
+     - AnnotatedEmitterAudio
      - 
      - r, m
      - 
    * - GLOBAL_SOFAConventionsVersion (*attribute*)
-     - 1.0
+     - 0.2
      - 
      - r, m
-     - 
-   * - GLOBAL_DataType (*attribute*)
-     - TF
-     - 
-     - r, m
-     - We store frequency-dependent data here
-   * - GLOBAL_RoomType (*attribute*)
-     - free field
-     - 
-     - m
-     - The room information can be arbitrary, but the spatial setup assumes free field.
-   * - GLOBAL_Title (*attribute*)
-     - 
-     - 
-     - m
-     - 
-   * - GLOBAL_DateCreated (*attribute*)
-     - 
-     - 
-     - m
-     - 
-   * - GLOBAL_DateModified (*attribute*)
-     - 
-     - 
-     - m
      - 
    * - GLOBAL_APIName (*attribute*)
      - 
@@ -135,8 +116,38 @@ This conventions stores directivities of acoustic sources (instruments, loudspea
      - 
      - r, m
      - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
    * - GLOBAL_AuthorContact (*attribute*)
      - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - Audio
+     - 
+     - r, m
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
      - 
      - m
      - 
@@ -145,10 +156,208 @@ This conventions stores directivities of acoustic sources (instruments, loudspea
      - 
      - m
      - 
-   * - GLOBAL_License (*attribute*)
-     - No license provided, ask the author for permission
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
      - 
      - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Position of the head. IC if not tracked, MC if tracked.
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - rC, rCM
+     - m
+     - Position of the ears. RC if not tracked, RCM if tracked.
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Position of the virtual ensemble. IC if not tracked, MC if tracked.
+   * - SourcePosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eC, eCM
+     - m
+     - Position of the virtual source(s). eC if not tracked, eCM if tracked.
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Must be of the same dimensionality as ListenerView.
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - Orientation of the head. IC if not tracked, MC if tracked.
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - M (*double*)
+     - 0
+     - m
+     - m
+     - Time stamp of the measurements in M, defines the size of M.
+   * - M_LongName (*attribute*)
+     - time
+     - 
+     - m
+     - Narrative name for M
+   * - M_Units (*attribute*)
+     - second
+     - 
+     - m
+     - Units used for M
+   * - Response (*string*)
+     - ['']
+     - I, C, S
+     - 
+     - the subject’s response
+   * - Response_Type (*attribute*)
+     - 
+     - 
+     - 
+     - type depends on the dimension
+   * - Response_LongName (*attribute*)
+     - 
+     - 
+     - 
+     - narrative description of the response type
+   * - Data_Emitter (*double*)
+     - [0, 0]
+     - In, En
+     - m
+     - audio data at the emitter(s); n=number of audio samples
+   * - Data_SamplingRate (*double*)
+     - 44100
+     - I
+     - m
+     - 
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+
+.. _AnnotatedReceiverAudio_0.2:
+
+**AnnotatedReceiverAudio v0.2**
+
+
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - AnnotatedReceiverAudio
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 0.2
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
      - 
    * - GLOBAL_ApplicationName (*attribute*)
      - 
@@ -160,56 +369,71 @@ This conventions stores directivities of acoustic sources (instruments, loudspea
      - 
      - 
      - 
-   * - GLOBAL_Comment (*attribute*)
+   * - GLOBAL_AuthorContact (*attribute*)
      - 
      - 
      - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - Audio
+     - 
+     - r, m
      - 
    * - GLOBAL_History (*attribute*)
      - 
      - 
      - 
      - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
    * - GLOBAL_References (*attribute*)
      - 
      - 
      - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
      - 
    * - GLOBAL_Origin (*attribute*)
      - 
      - 
      - 
      - 
-   * - GLOBAL_DatabaseName (*attribute*)
+   * - GLOBAL_DateCreated (*attribute*)
      - 
      - 
      - m
-     - Name of the database. Used for classification of the data
-   * - GLOBAL_Musician (*attribute*)
      - 
-     - 
-     - 
-     - Narrative description of the musician such as position, behavior, or personal data if not data-protected, e.g., 'Christiane Schmidt sitting on the chair', or 'artificial excitation by R2D2'.
-   * - GLOBAL_Description (*attribute*)
-     - 
-     - 
-     - 
-     - Narrative description of a measurement. For musical instruments/singers, the note (C1, D1, etc) or the dynamic (pp., ff., etc), or the string played, the playing style (pizzicato, legato, etc.), or the type of excitation (e.g., hit location of a cymbal). For loudspeakers, the system and driver units.
-   * - GLOBAL_SourceType (*attribute*)
+   * - GLOBAL_DateModified (*attribute*)
      - 
      - 
      - m
-     - Narrative description of the acoustic source, e.g., 'Violin', 'Female singer', or '2-way loudspeaker'
-   * - GLOBAL_SourceManufacturer (*attribute*)
+     - 
+   * - GLOBAL_Title (*attribute*)
      - 
      - 
      - m
-     - Narrative description of the manufacturer of the source, e.g., 'Stradivari, Lady Blunt, 1721' or 'LoudspeakerCompany'
+     - 
    * - ListenerPosition (*double*)
      - [0, 0, 0]
      - IC, MC
      - m
-     - Position of the microphone array during the measurements.
+     - Position of the head. IC if not tracked, MC if tracked.
    * - ListenerPosition_Type (*attribute*)
      - cartesian
      - 
@@ -220,38 +444,18 @@ This conventions stores directivities of acoustic sources (instruments, loudspea
      - 
      - m
      - 
-   * - ListenerView (*double*)
-     - [1, 0, 0]
-     - IC, MC
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - rC, rCM
      - m
-     - Orientation of the microphone array
-   * - ListenerView_Type (*attribute*)
+     - Position of the ears. RC if not tracked, RCM if tracked.
+   * - ReceiverPosition_Type (*attribute*)
      - cartesian
      - 
      - m
      - 
-   * - ListenerView_Units (*attribute*)
-     - metre
-     - 
-     - m
-     - 
-   * - ListenerUp (*double*)
-     - [0, 0, 1]
-     - IC, MC
-     - m
-     - Up vector of the microphone array
-   * - ReceiverPosition (*double*)
-     - [0, 0, 1]
-     - IC, RC, RCM
-     - m
-     - Positions of the microphones during the measurements (relative to the Listener)
-   * - ReceiverPosition_Type (*attribute*)
-     - spherical
-     - 
-     - m
-     - 
    * - ReceiverPosition_Units (*attribute*)
-     - degree, degree, metre
+     - metre
      - 
      - m
      - 
@@ -259,7 +463,7 @@ This conventions stores directivities of acoustic sources (instruments, loudspea
      - [0, 0, 0]
      - IC, MC
      - m
-     - Position of the acoustic source (instrument)
+     - Position of the virtual ensemble. IC if not tracked, MC if tracked.
    * - SourcePosition_Type (*attribute*)
      - cartesian
      - 
@@ -270,46 +474,11 @@ This conventions stores directivities of acoustic sources (instruments, loudspea
      - 
      - m
      - 
-   * - SourcePosition_Reference (*attribute*)
-     - 
-     - 
-     - m
-     - Narrative description of the spatial reference of the source position, e.g., for the trumpet, 'The bell'. Mandatory in order to provide a reference across different instruments
-   * - SourceView (*double*)
-     - [1, 0, 0]
-     - IC, MC
-     - m
-     - Orientation of the acoustic source (instrument)
-   * - SourceView_Type (*attribute*)
-     - cartesian
-     - 
-     - m
-     - 
-   * - SourceView_Units (*attribute*)
-     - metre
-     - 
-     - m
-     - 
-   * - SourceView_Reference (*attribute*)
-     - 
-     - 
-     - m
-     - Narrative description of the spatial reference of the source view, e.g., for the trumpet, 'Viewing direction of the bell'. Mandatory in order to provide a reference across different instruments
-   * - SourceUp (*double*)
-     - [0, 0, 1]
-     - IC, MC
-     - m
-     - Up vector of the acoustic source (instrument)
-   * - SourceUp_Reference (*attribute*)
-     - 
-     - 
-     - m
-     - Narrative description of the spatial reference of the source up, e.g., for the trumpet, 'Along the keys, keys up'. Mandatory in order to provide a reference across different instruments
    * - EmitterPosition (*double*)
      - [0, 0, 0]
-     - IC, MC
+     - eC, eCM
      - m
-     - A more detailed structure of the Source. In a simple settings, a single Emitter is considered that is collocated with the source.
+     - Position of the virtual source(s). eC if not tracked, eCM if tracked.
    * - EmitterPosition_Type (*attribute*)
      - cartesian
      - 
@@ -320,51 +489,71 @@ This conventions stores directivities of acoustic sources (instruments, loudspea
      - 
      - m
      - 
-   * - EmitterDescription (*string*)
-     - ['']
-     - IS, MS
-     - 
-     - A more detailed structure of the source. In a simple setting, a single Emitter is considered that is collocated with the source. In a more complicated setting, this may be the strings of a violin or the units of a loudspeaker.
-   * - MIDINote (*double*)
-     - 0
-     - I, M
-     - 
-     - Defines the note played by the source during the measurement. The note is specified a MIDI note by the [https://www.midi.org/specifications-old/item/the-midi-1-0-specification MIDI specifications, version 1.0]. Not mandatory, but recommended for tonal instruments.
-   * - Description (*string*)
-     - ['']
-     - MS
-     - 
-     - This variable is used when the description varies with M.
-   * - SourceTuningFrequency (*double*)
-     - 440
-     - I, M
-     - 
-     - Frequency (in hertz) to which a musical instrument is tuned to corresponding to the note A4 (MIDINote=69). Recommended for tonal instruments.
-   * - N (*double*)
-     - 0
-     - N
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
      - m
-     - Frequency values
-   * - N_LongName (*attribute*)
-     - frequency
+     - Must be of the same dimensionality as ListenerView.
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - Orientation of the head. IC if not tracked, MC if tracked.
+   * - ListenerView_Type (*attribute*)
+     - cartesian
      - 
      - m
      - 
-   * - N_Units (*attribute*)
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - M (*double*)
+     - 0
+     - m
+     - m
+     - Time stamp of the measurements in M, defines the size of M.
+   * - M_LongName (*attribute*)
+     - time
+     - 
+     - m
+     - Narrative name for M
+   * - M_Units (*attribute*)
+     - second
+     - 
+     - m
+     - Units used for M
+   * - Response (*string*)
+     - ['']
+     - I, C, S
+     - 
+     - the subject’s response
+   * - Response_Type (*attribute*)
+     - 
+     - 
+     - 
+     - type depends on the dimension
+   * - Response_LongName (*attribute*)
+     - 
+     - 
+     - 
+     - narrative description of the response type
+   * - Data_Receiver (*double*)
+     - [0, 0]
+     - In, Rn
+     - m
+     - (binaural) audio data at the receivers; n=number of audio samples
+   * - Data_SamplingRate (*double*)
+     - 44100
+     - I
+     - m
+     - 
+   * - Data_SamplingRate_Units (*attribute*)
      - hertz
      - 
      - m
-     - Units used for N
-   * - Data_Real (*double*)
-     - 0
-     - mrn
-     - m
-     - Real part of the complex spectrum. The default value 0 indicates that all data fields are initialized with zero values.
-   * - Data_Imag (*double*)
-     - 0
-     - MRN
-     - m
-     - Imaginary part of the complex spectrum
+     - 
 
 :ref:`back to top <conventions>`
 
@@ -4384,6 +4573,801 @@ For measuring SRIRs in a single room with a single excitation source (e.g., a lo
 Deprecated
 ==========
 
+.. _AnnotatedEmitterAudio_0.1:
+
+**AnnotatedEmitterAudio v0.1**
+
+This convention is deprecated. Use :ref:`AnnotatedEmitterAudio_0.2 <AnnotatedEmitterAudio_0.2>` instead.
+
+
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - AnnotatedEmitterAudio
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 0.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - Audio
+     - 
+     - r, m
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Position of the head. IC if not tracked, MC if tracked.
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - rC, rCM
+     - m
+     - Position of the ears. RC if not tracked, RCM if tracked.
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Position of the virtual ensemble. IC if not tracked, MC if tracked.
+   * - SourcePosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eC, eCM
+     - m
+     - Position of the virtual source(s). eC if not tracked, eCM if tracked.
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Must be of the same dimensionality as ListenerView.
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - Orientation of the head. IC if not tracked, MC if tracked.
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - M (*double*)
+     - 0
+     - m
+     - m
+     - Time stamp of the measurements in M, defines the size of M.
+   * - M_LongName (*attribute*)
+     - time
+     - 
+     - m
+     - Narrative name for M
+   * - M_Units (*attribute*)
+     - second
+     - 
+     - m
+     - Units used for M
+   * - Response (*attribute*)
+     - 
+     - I, C, S
+     - 
+     - the subject’s response
+   * - Response_Type (*attribute*)
+     - 
+     - I, C, S
+     - 
+     - type depends on the dimension
+   * - Response_LongName (*attribute*)
+     - 
+     - S
+     - 
+     - narrative description of the response type
+   * - Data_Emitter (*double*)
+     - [0, 0]
+     - In, En
+     - m
+     - audio data at the emitter(s); n=number of audio samples
+   * - Data_SamplingRate (*double*)
+     - 44100
+     - I
+     - m
+     - 
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+
+.. _AnnotatedReceiverAudio_0.1:
+
+**AnnotatedReceiverAudio v0.1**
+
+This convention is deprecated. Use :ref:`AnnotatedReceiverAudio_0.2 <AnnotatedReceiverAudio_0.2>` instead.
+
+
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - AnnotatedReceiverAudio
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 0.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - Audio
+     - 
+     - r, m
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Position of the head. IC if not tracked, MC if tracked.
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - rC, rCM
+     - m
+     - Position of the ears. RC if not tracked, RCM if tracked.
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Position of the virtual ensemble. IC if not tracked, MC if tracked.
+   * - SourcePosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eC, eCM
+     - m
+     - Position of the virtual source(s). eC if not tracked, eCM if tracked.
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Must be of the same dimensionality as ListenerView.
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - Orientation of the head. IC if not tracked, MC if tracked.
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - M (*double*)
+     - 0
+     - m
+     - m
+     - Time stamp of the measurements in M, defines the size of M.
+   * - M_LongName (*attribute*)
+     - time
+     - 
+     - m
+     - Narrative name for M
+   * - M_Units (*attribute*)
+     - second
+     - 
+     - m
+     - Units used for M
+   * - Response (*attribute*)
+     - 
+     - I, C, S
+     - 
+     - the subject’s response
+   * - Response_Type (*attribute*)
+     - 
+     - I, C, S
+     - 
+     - type depends on the dimension
+   * - Response_LongName (*attribute*)
+     - 
+     - S
+     - 
+     - narrative description of the response type
+   * - Data_Receiver (*double*)
+     - [0, 0]
+     - In, Rn
+     - m
+     - (binaural) audio data at the receivers; n=number of audio samples
+   * - Data_SamplingRate (*double*)
+     - 44100
+     - I
+     - m
+     - 
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+
+.. _FreeFieldDirectivityTF_1.0:
+
+**FreeFieldDirectivityTF v1.0**
+
+This convention is deprecated. Use :ref:`FreeFieldDirectivityTF_1.1 <FreeFieldDirectivityTF_1.1>` instead.
+
+This conventions stores directivities of acoustic sources (instruments, loudspeakers, singers, talkers, etc) in the frequency domain for multiple musical notes in free field.
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - FreeFieldDirectivityTF
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 1.0
+     - 
+     - r, m
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - TF
+     - 
+     - r, m
+     - We store frequency-dependent data here
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - The room information can be arbitrary, but the spatial setup assumes free field.
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DatabaseName (*attribute*)
+     - 
+     - 
+     - m
+     - Name of the database. Used for classification of the data
+   * - GLOBAL_Musician (*attribute*)
+     - 
+     - 
+     - 
+     - Narrative description of the musician such as position, behavior, or personal data if not data-protected, e.g., 'Christiane Schmidt sitting on the chair', or 'artificial excitation by R2D2'.
+   * - GLOBAL_Description (*attribute*)
+     - 
+     - 
+     - 
+     - Narrative description of a measurement. For musical instruments/singers, the note (C1, D1, etc) or the dynamic (pp., ff., etc), or the string played, the playing style (pizzicato, legato, etc.), or the type of excitation (e.g., hit location of a cymbal). For loudspeakers, the system and driver units.
+   * - GLOBAL_SourceType (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the acoustic source, e.g., 'Violin', 'Female singer', or '2-way loudspeaker'
+   * - GLOBAL_SourceManufacturer (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the manufacturer of the source, e.g., 'Stradivari, Lady Blunt, 1721' or 'LoudspeakerCompany'
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Position of the microphone array during the measurements.
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - Orientation of the microphone array
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Up vector of the microphone array
+   * - ReceiverPosition (*double*)
+     - [0, 0, 1]
+     - IC, RC, RCM
+     - m
+     - Positions of the microphones during the measurements (relative to the Listener)
+   * - ReceiverPosition_Type (*attribute*)
+     - spherical
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - degree, degree, metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Position of the acoustic source (instrument)
+   * - SourcePosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition_Reference (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the spatial reference of the source position, e.g., for the trumpet, 'The bell'. Mandatory in order to provide a reference across different instruments
+   * - SourceView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - Orientation of the acoustic source (instrument)
+   * - SourceView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourceView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourceView_Reference (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the spatial reference of the source view, e.g., for the trumpet, 'Viewing direction of the bell'. Mandatory in order to provide a reference across different instruments
+   * - SourceUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Up vector of the acoustic source (instrument)
+   * - SourceUp_Reference (*attribute*)
+     - 
+     - 
+     - m
+     - Narrative description of the spatial reference of the source up, e.g., for the trumpet, 'Along the keys, keys up'. Mandatory in order to provide a reference across different instruments
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - A more detailed structure of the Source. In a simple settings, a single Emitter is considered that is collocated with the source.
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - EmitterDescription (*string*)
+     - ['']
+     - IS, MS
+     - 
+     - A more detailed structure of the source. In a simple setting, a single Emitter is considered that is collocated with the source. In a more complicated setting, this may be the strings of a violin or the units of a loudspeaker.
+   * - MIDINote (*double*)
+     - 0
+     - I, M
+     - 
+     - Defines the note played by the source during the measurement. The note is specified a MIDI note by the [https://www.midi.org/specifications-old/item/the-midi-1-0-specification MIDI specifications, version 1.0]. Not mandatory, but recommended for tonal instruments.
+   * - Description (*string*)
+     - ['']
+     - MS
+     - 
+     - This variable is used when the description varies with M.
+   * - SourceTuningFrequency (*double*)
+     - 440
+     - I, M
+     - 
+     - Frequency (in hertz) to which a musical instrument is tuned to corresponding to the note A4 (MIDINote=69). Recommended for tonal instruments.
+   * - N (*double*)
+     - 0
+     - N
+     - m
+     - Frequency values
+   * - N_LongName (*attribute*)
+     - frequency
+     - 
+     - m
+     - 
+   * - N_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - Units used for N
+   * - Data_Real (*double*)
+     - 0
+     - mrn
+     - m
+     - Real part of the complex spectrum. The default value 0 indicates that all data fields are initialized with zero values.
+   * - Data_Imag (*double*)
+     - 0
+     - MRN
+     - m
+     - Imaginary part of the complex spectrum
+
+:ref:`back to top <conventions>`
+
 .. _GeneralFIRE_1.0:
 
 **GeneralFIRE v1.0**
@@ -6574,6 +7558,526 @@ This convention stores arbitrary number of receivers while providing an informat
    * - Data_Delay (*double*)
      - [0]
      - IR, MR
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+
+.. _SingleTrackedAudio_0.1:
+
+**SingleTrackedAudio v0.1**
+
+This convention is deprecated. Use AnnotatedEmitterAudio or AnnotatedReceiverAudio instead.
+
+
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - SingleTrackedAudio
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 0.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - FIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Position of the head. IC if not tracked, MC if tracked.
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - IC, RC, RCM
+     - m
+     - Position of the ears. RC if not tracked, RCM if tracked.
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Position of the virtual ensemble. IC if not tracked, MC if tracked.
+   * - SourcePosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eC, eCM
+     - m
+     - Position of the virtual source(s). eC if not tracked, eCM if tracked.
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Must be of the same dimensionality as ListenerView.
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - Orientation of the head. IC if not tracked, MC if tracked.
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - M (*double*)
+     - 0
+     - m
+     - m
+     - Time stamp of the measurements in M,defines the size of M.
+   * - EmitterUp (*double*)
+     - [0, 0, 0]
+     - EC, ECM
+     - 
+     - Must be of the same dimensionality as EmitterView.
+   * - EmitterView (*double*)
+     - [0, 0, 0]
+     - EC, ECM
+     - 
+     - Orientation of the virtual source(s). EC if not tracked, ECM if tracked.
+   * - EmitterView_Type (*attribute*)
+     - cartesian
+     - 
+     - 
+     - 
+   * - EmitterView_Units (*attribute*)
+     - metre
+     - 
+     - 
+     - 
+   * - M_LongName (*attribute*)
+     - time
+     - 
+     - m
+     - Narrative name for M
+   * - M_Units (*attribute*)
+     - second
+     - 
+     - m
+     - Units used for M
+   * - Data_Sample (*double*)
+     - [0, 0]
+     - rn
+     - m
+     - n=number of audio samples
+   * - Data_SamplingRate (*double*)
+     - 44100
+     - I
+     - m
+     - 
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
+     - m
+     - 
+
+:ref:`back to top <conventions>`
+
+.. _SingleTrackedAudio_0.2:
+
+**SingleTrackedAudio v0.2**
+
+This convention is deprecated. Use AnnotatedEmitterAudio or AnnotatedReceiverAudio instead.
+
+
+
+.. list-table::
+   :widths: 20 50 25 30 100
+   :header-rows: 1
+
+   * - Name (Type)
+     - Default
+     - Dim.
+     - Flags
+     - Comment
+   * - GLOBAL_Conventions (*attribute*)
+     - SOFA
+     - 
+     - r, m
+     - 
+   * - GLOBAL_Version (*attribute*)
+     - 2.1
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventions (*attribute*)
+     - SingleTrackedAudio
+     - 
+     - r, m
+     - 
+   * - GLOBAL_SOFAConventionsVersion (*attribute*)
+     - 0.2
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIName (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_APIVersion (*attribute*)
+     - 
+     - 
+     - r, m
+     - 
+   * - GLOBAL_ApplicationName (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_ApplicationVersion (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_AuthorContact (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Comment (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DataType (*attribute*)
+     - FIR
+     - 
+     - r, m
+     - 
+   * - GLOBAL_History (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_License (*attribute*)
+     - No license provided, ask the author for permission
+     - 
+     - m
+     - 
+   * - GLOBAL_Organization (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_References (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_RoomType (*attribute*)
+     - free field
+     - 
+     - m
+     - 
+   * - GLOBAL_Origin (*attribute*)
+     - 
+     - 
+     - 
+     - 
+   * - GLOBAL_DateCreated (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_DateModified (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - GLOBAL_Title (*attribute*)
+     - 
+     - 
+     - m
+     - 
+   * - ListenerPosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Position of the head. IC if not tracked, MC if tracked.
+   * - ListenerPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ReceiverPosition (*double*)
+     - [[0, 0.09, 0], [0, -0.09, 0]]
+     - IC, RC, RCM
+     - m
+     - Position of the ears. RC if not tracked, RCM if tracked.
+   * - ReceiverPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ReceiverPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - SourcePosition (*double*)
+     - [0, 0, 0]
+     - IC, MC
+     - m
+     - Position of the virtual ensemble. IC if not tracked, MC if tracked.
+   * - SourcePosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - SourcePosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - EmitterPosition (*double*)
+     - [0, 0, 0]
+     - eC, eCM
+     - m
+     - Position of the virtual source(s). eC if not tracked, eCM if tracked.
+   * - EmitterPosition_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - EmitterPosition_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - ListenerUp (*double*)
+     - [0, 0, 1]
+     - IC, MC
+     - m
+     - Must be of the same dimensionality as ListenerView.
+   * - ListenerView (*double*)
+     - [1, 0, 0]
+     - IC, MC
+     - m
+     - Orientation of the head. IC if not tracked, MC if tracked.
+   * - ListenerView_Type (*attribute*)
+     - cartesian
+     - 
+     - m
+     - 
+   * - ListenerView_Units (*attribute*)
+     - metre
+     - 
+     - m
+     - 
+   * - EmitterUp (*double*)
+     - [0, 0, 0]
+     - EC, ECM
+     - 
+     - Must be of the same dimensionality as EmitterView.
+   * - EmitterView (*double*)
+     - [0, 0, 0]
+     - EC, ECM
+     - 
+     - Orientation of the virtual source(s). EC if not tracked, ECM if tracked.
+   * - EmitterView_Type (*attribute*)
+     - cartesian
+     - 
+     - 
+     - 
+   * - EmitterView_Units (*attribute*)
+     - metre
+     - 
+     - 
+     - 
+   * - M (*double*)
+     - 0
+     - m
+     - m
+     - Time stamp of the measurements in M,defines the size of M.
+   * - M_LongName (*attribute*)
+     - time
+     - 
+     - m
+     - Narrative name for M
+   * - M_Units (*attribute*)
+     - second
+     - 
+     - m
+     - Units used for M
+   * - Response (*attribute*)
+     - 
+     - S, C, I
+     - 
+     - the subject’s response
+   * - Response_Type (*attribute*)
+     - 
+     - S, C, I
+     - 
+     - type depends on the dimension
+   * - Response_LongName (*attribute*)
+     - Date
+     - S
+     - 
+     - narrative description of the response type
+   * - Data_Receiver (*double*)
+     - [0, 0]
+     - nR
+     - 
+     - (binaural) audio data at the receivers; n=number of audio samples
+   * - Data_Emitter (*double*)
+     - [0, 0]
+     - nE
+     - 
+     - (source) audio data at the emitters; n=number of audio samples
+   * - Data_SamplingRate (*double*)
+     - 44100
+     - I
+     - m
+     - 
+   * - Data_SamplingRate_Units (*attribute*)
+     - hertz
+     - 
      - m
      - 
 

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -203,7 +203,7 @@ def _read_netcdf(filename, verify, verbose, mode):
                f"{', '.join(custom)}"))
 
     # set default for verify
-    if verify is None:
+    if verify == 'auto':
         verify = True if parse(version) >= parse('1.0') else False
 
     # update api

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -9,7 +9,7 @@ import sofar as sf
 from .utils import _verify_convention_and_version, _atleast_nd
 
 
-def read_sofa(filename, verify=None, verbose=True):
+def read_sofa(filename, verify='auto', verbose=True):
     """
     Read SOFA file from disk and convert it to SOFA object.
 
@@ -24,7 +24,7 @@ def read_sofa(filename, verify=None, verbose=True):
         Verify and update the SOFA object by calling :py:func:`~Sofa.verify`.
         This helps to find potential errors in the default values and is thus
         recommended. If reading a file does not work, try to call `Sofa` with
-        ``verify=False``. The default is ``None`` defaults to ``True`` for
+        ``verify=False``. The default is ``'auto'`` defaults to ``True`` for
         stable conventions with versions of 1.0 or higher and to ``False``
         otherwise.
     verbose : bool, optional

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -9,7 +9,7 @@ import sofar as sf
 from .utils import _verify_convention_and_version, _atleast_nd
 
 
-def read_sofa(filename, verify=True, verbose=True):
+def read_sofa(filename, verify=None, verbose=True):
     """
     Read SOFA file from disk and convert it to SOFA object.
 
@@ -24,7 +24,9 @@ def read_sofa(filename, verify=True, verbose=True):
         Verify and update the SOFA object by calling :py:func:`~Sofa.verify`.
         This helps to find potential errors in the default values and is thus
         recommended. If reading a file does not work, try to call `Sofa` with
-        ``verify=False``. The default is ``True``.
+        ``verify=False``. The default is ``None`` defaults to ``True`` for
+        stable conventions with versions of 1.0 or higher and to ``False``
+        otherwise.
     verbose : bool, optional
         Print the names of detected custom variables and attributes. The
         default is ``True``
@@ -199,6 +201,10 @@ def _read_netcdf(filename, verify, verbose, mode):
         print(("SOFA file contained custom entries\n"
                "----------------------------------\n"
                f"{', '.join(custom)}"))
+
+    # set default for verify
+    if verify is None:
+        verify = True if parse(version) >= parse('1.0') else False
 
     # update api
     if verify:

--- a/sofar/sofa.py
+++ b/sofar/sofa.py
@@ -31,7 +31,7 @@ class Sofa():
         Verify the SOFA object by calling :py:func:`~Sofa.verify`. This helps
         to find potential errors in the default values and is thus recommended
         If creating a file does not work, try to call `Sofa` with
-        ``verify=False``. The default ``None`` defaults to ``True`` for
+        ``verify=False``. The default ``'auto'`` defaults to ``True`` for
         stable conventions with versions of 1.0 or higher and to ``False``
         otherwise.
 
@@ -88,7 +88,7 @@ class Sofa():
     _read_only_attr = []
 
     def __init__(self, convention, mandatory=False, version="latest",
-                 verify=None):
+                 verify='auto'):
         """See class docstring"""
 
         # get convention
@@ -106,7 +106,7 @@ class Sofa():
             # set default for verify
             version = \
                 self._convention['GLOBAL_SOFAConventionsVersion']['default']
-            if verify is None:
+            if verify == 'auto':
                 verify = True if parse(version) >= parse('1.0') else False
 
             # add and update the API
@@ -408,7 +408,7 @@ class Sofa():
             console.
         issue_handling : str, optional
             Defines how issues detected during verification of the SOFA object
-            are handeled (see :py:func:`~sofar.sofar.Sofa.verify`)
+            are handled (see :py:func:`~sofar.sofar.Sofa.verify`)
 
             ``'raise'``
                 Warnings and errors are raised if issues are detected

--- a/sofar/sofa.py
+++ b/sofar/sofa.py
@@ -711,7 +711,7 @@ class Sofa():
         setattr(self, key, value)
         self.protected = True
 
-    def upgrade_convention(self, target=None, verify=True):
+    def upgrade_convention(self, target=None, verify='auto'):
         """
         Upgrade Sofa data to newer conventions.
 
@@ -729,7 +729,9 @@ class Sofa():
             conventions to which the data can be updated.
         verify : bool, optional
             Flag to specify if the data should be verified after the upgrade
-            using :py:func:`~Sofa.verify`. The default is ``True``.
+            using :py:func:`~Sofa.verify`. The default ``'auto'`` defaults to
+            ``True`` for stable conventions with versions of 1.0 or higher and
+            to ``False`` otherwise.
 
         Returns
         -------
@@ -872,6 +874,10 @@ class Sofa():
         if upgrade["message"] is not None:
             print(upgrade["message"])
 
+        # set default for verify
+        if verify == 'auto':
+            version = self.GLOBAL_SOFAConventionsVersion
+            verify = True if parse(version) >= parse('1.0') else False
         if verify:
             self.verify()
 

--- a/sofar/sofa.py
+++ b/sofar/sofa.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import platform
 import numpy as np
 import warnings
+from packaging.version import parse
 from copy import deepcopy
 import sofar as sf
 from .utils import (_nd_newaxis, _atleast_nd, _get_conventions,
@@ -30,7 +31,9 @@ class Sofa():
         Verify the SOFA object by calling :py:func:`~Sofa.verify`. This helps
         to find potential errors in the default values and is thus recommended
         If creating a file does not work, try to call `Sofa` with
-        ``verify=False``. The default is ``True``.
+        ``verify=False``. The default ``None`` defaults to ``True`` for
+        stable conventions with versions of 1.0 or higher and to ``False``
+        otherwise.
 
     Returns
     -------
@@ -85,7 +88,7 @@ class Sofa():
     _read_only_attr = []
 
     def __init__(self, convention, mandatory=False, version="latest",
-                 verify=True):
+                 verify=None):
         """See class docstring"""
 
         # get convention
@@ -100,11 +103,24 @@ class Sofa():
             # add attributes with default values
             self._convention_to_sofa(mandatory)
 
+            # set default for verify
+            version = \
+                self._convention['GLOBAL_SOFAConventionsVersion']['default']
+            if verify is None:
+                verify = True if parse(version) >= parse('1.0') else False
+
             # add and update the API
             # (mandatory=False can not be verified because some conventions
             # have default values that have optional variables as dependencies)
             if verify and not mandatory:
                 self.verify(mode="read")
+            # warning for preliminary conventions if verification is bypassed
+            elif parse(version) < parse('1.0'):
+                warnings.warn(UserWarning((
+                    f"Detected preliminary conventions version {version}. "
+                    "Upgrade data to version >= 1.0 if possible. Preliminary "
+                    "conventions might change in the future, which could "
+                    "invalidate data that was written before the changes.")))
 
             self.protected = True
         else:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -13,6 +13,7 @@ from pytest import raises
 import numpy as np
 import numpy.testing as npt
 from netCDF4 import Dataset
+from packaging.version import parse
 
 
 def test_read_write_sofa(capfd):
@@ -165,11 +166,14 @@ def test_roundtrip(mandatory):
     for name, version in names_versions:
         print(f"Testing: {name} {version}")
 
-        if name in deprecations["GLOBAL:SOFAConventions"]:
-            # deprecated conventions can not be written
+        # writing deprecated and proposed conventions is not tested
+        if name in deprecations["GLOBAL:SOFAConventions"] or \
+                parse(version) < parse('1.0'):
             sofa = sf.Sofa(name, mandatory, version, verify=False)
-            with pytest.warns(UserWarning, match="deprecations"):
-                sofa.verify(mode="read")
+            # non stable conventions are not verified
+            if parse(version) >= parse('1.0'):
+                with pytest.warns(UserWarning, match="deprecations"):
+                    sofa.verify(mode="read")
         else:
             # test full round-trip for other conventions
             file = os.path.join(temp_dir.name, name + ".sofa")

--- a/tests/test_sofa_upgrade_conventions.py
+++ b/tests/test_sofa_upgrade_conventions.py
@@ -85,10 +85,15 @@ def test_upgrade_conventions(path, capfd):
     out, _ = capfd.readouterr()
 
     # don't verify conventions that might require user action after
-    if os.path.basename(path) in ["FreeFieldDirectivityTF_1.0.json"]:
+    if os.path.basename(path) in [
+            "FreeFieldDirectivityTF_1.0.json",
+            "SingleTrackedAudio_0.1.json",
+            "SingleTrackedAudio_0.2.json"]:
         # FreeFieldDirectivityTF_1.0
         # - optional dependency GLOBAL_EmitterDescription
         #   might need to be added
+        # SingleTrackedAudio_0.x
+        # - can be updated to multiple conventions depending on the content
         verify = False
     else:
         verify = True
@@ -98,5 +103,9 @@ def test_upgrade_conventions(path, capfd):
             sofa.upgrade_convention(target, verify=verify)
             out, _ = capfd.readouterr()
             assert "Upgrading" in out
+    elif deprecated:
+        sofa.upgrade_convention()
+        out, _ = capfd.readouterr()
+        assert "is missing upgrade rules" in out
     else:
         assert not deprecated


### PR DESCRIPTION
- [x] Wait for fixes of AnnotatedAudio in SOFAtoolbox (https://github.com/sofacoustics/SOFAtoolbox/issues/78)
- [x] Update sofa_conventions submodule to inlcude AnnotatedAudio and SingleTrackedAudio conventions
- [x] non-stable conventions are now flagged by version < 1.0 and are not verified by default
- [x] New default parameter and handling of `verify` parameter. Unstable conventions with versions <1.0 are now not verified by default. This was required due to how the conventions are handled on sofaconventions.org.
- [x] Check for required changes in the documentation and exaples