### PR TITLE
Replace latest with stable when linking to parts of the docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -127,7 +127,7 @@ You can create an html report on the test `coverage <https://coverage.readthedoc
 Writing the Documentation
 -------------------------
 
-Sofar follows the `numpy style guide <https://numpydoc.readthedocs.io/en/latest/format.html>`_ for the docstring. A docstring has to consist at least of
+Sofar follows the `numpy style guide <https://numpydoc.readthedocs.io/en/stable/format.html>`_ for the docstring. A docstring has to consist at least of
 
 - A short and/or extended summary,
 - the Parameters section, and

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Refer to the `contribution guidelines`_ for more information.
 .. _sofa_conventions : https://github.com/pyfar/sofa_conventions
 .. _contribution guidelines: https://github.com/pyfar/sofar/blob/develop/CONTRIBUTING.rst
 .. _pyfar.org: https://pyfar.org
-.. _read the docs: https://sofar.readthedocs.io/en/latest
+.. _read the docs: https://sofar.readthedocs.io/en/stable
 .. _sofaconventions.org: https://sofaconventions.org
 
 References

--- a/docs/_templates/navbar-nav.html
+++ b/docs/_templates/navbar-nav.html
@@ -3,37 +3,37 @@
       <ul class="bd-navbar-elements navbar-nav">
 
                         <li class="nav-item">
-                            <a class="nav-link" href="https://pyfar-gallery.readthedocs.io/en/latest/">
+                            <a class="nav-link" href="https://pyfar-gallery.readthedocs.io">
                             Home
                             </a>
                         </li>
 
                         <li class="nav-item">
-                            <a class="nav-link" href="https://pyfar-gallery.readthedocs.io/en/latest/examples_gallery.html">
+                            <a class="nav-link" href="https://pyfar-gallery.readthedocs.io/en/stable/examples_gallery.html">
                                 Examples
                             </a>
                         </li>
 
                         <li class="nav-item">
-                            <a class="nav-link" href="https://pyfar.readthedocs.io/en/stable/">
+                            <a class="nav-link" href="https://pyfar.readthedocs.io">
                               pyfar
                             </a>
                           </li>
 
                         <li class="nav-item">
-                          <a class="nav-link" href="https://sofar.readthedocs.io/en/stable/">
+                          <a class="nav-link" href="https://sofar.readthedocs.io">
                             sofar
                           </a>
                         </li>
 
                         <li class="nav-item">
-                          <a class="nav-link" href="https://spharpy.readthedocs.io/en/latest/">
+                          <a class="nav-link" href="https://spharpy.readthedocs.io">
                             spharpy
                           </a>
                         </li>
 
                         <li class="nav-item">
-                          <a class="nav-link" href="https://pyrato.readthedocs.io/en/latest/">
+                          <a class="nav-link" href="https://pyrato.readthedocs.io">
                             pyrato
                           </a>
                         </li>

--- a/docs/working_with_sofa_files.rst
+++ b/docs/working_with_sofa_files.rst
@@ -119,7 +119,7 @@ Next steps
 For detailed information about sofar refer to the :ref:`sofar_SOFA` and :ref:`sofar_functions` documentation.
 Pyfar also offers methods for digital signal processing that wont be detailed
 here. A god way to dive into that is the
-`pyfar documentation <https://pyfar.readthedocs.io/en/latest/>`_ and the
+`pyfar documentation <https://pyfar.readthedocs.io/en/stable/>`_ and the
 `pyfar examples notebook <https://mybinder.org/v2/gh/pyfar/pyfar/main?filepath=examples%2Fpyfar_demo.ipynb>`_.
 
 .. |source_lateral| image:: resources/working_with_sofa_source_lateral.png

--- a/sofar/sofa.py
+++ b/sofar/sofa.py
@@ -73,7 +73,7 @@ class Sofa():
 
 
     For more examples refer to the `Quick tour of SOFA and sofar` at
-    https://sofar.readthedocs.io/en/latest/
+    https://sofar.readthedocs.io/en/stable/
     """
 
     # these have to be set here, because they are used in __setattr__ and


### PR DESCRIPTION
We're often linking to the latest version of the docs, which points to the latest commit on the main branch.
This is replaced with the stable version, which is the latest tagged commit.