### PR TITLE
Update parsing of csv files from github/SOFAtoolbox

### DIFF
--- a/sofar/update_conventions.py
+++ b/sofar/update_conventions.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+import re
 import glob
 import json
 import requests
@@ -377,13 +378,18 @@ def _check_congruency(save_dir=None, branch="master"):
 
     # get file names of conventions from github
     url = urls_check[1]
-    page = requests.get(url).json()
-    sofatoolbox = []
-    for content in page["payload"]["tree"]["items"]:
-        if content["contentType"] == "file" and \
-                content["path"].startswith("SOFAtoolbox/conventions") and \
-                content["name"].endswith("csv"):
-            sofatoolbox.append(content["name"])
+    page = requests.get(url).text
+    sofatoolbox = re.findall(
+        r'"SOFAtoolbox/conventions/([^"]+\.csv)"', page)
+
+    # This worked before approx. March 2024. Old version is kept for reference.
+    # page = requests.get(url).json()
+    # sofatoolbox = []
+    # for content in page["payload"]["tree"]["items"]:
+    #     if content["contentType"] == "file" and \
+    #             content["path"].startswith("SOFAtoolbox/conventions") and \
+    #             content["name"].endswith("csv"):
+    #         sofatoolbox.append(content["name"])
 
     if not sofatoolbox:
         raise ValueError(f"Did not find any conventions at {url}")

--- a/sofar/update_conventions.py
+++ b/sofar/update_conventions.py
@@ -382,15 +382,6 @@ def _check_congruency(save_dir=None, branch="master"):
     sofatoolbox = re.findall(
         r'"SOFAtoolbox/conventions/([^"]+\.csv)"', page)
 
-    # This worked before approx. March 2024. Old version is kept for reference.
-    # page = requests.get(url).json()
-    # sofatoolbox = []
-    # for content in page["payload"]["tree"]["items"]:
-    #     if content["contentType"] == "file" and \
-    #             content["path"].startswith("SOFAtoolbox/conventions") and \
-    #             content["name"].endswith("csv"):
-    #         sofatoolbox.append(content["name"])
-
     if not sofatoolbox:
         raise ValueError(f"Did not find any conventions at {url}")
 


### PR DESCRIPTION
Closes #84 

Updated parsing data from the SOFAtoolbox html. I looked into cloning instead, but there seems to be no way to clone a single folder and I did not want to clone the entire 64 MB repo every time that the testing is ran: ['Note that this will still download the whole repository from the server – only the checkout is reduced in size. At the moment it is not possible to clone only a single directory.'](https://stackoverflow.com/questions/600079/how-do-i-clone-a-subdirectory-only-of-a-git-repository)