### PR TITLE
Remove explicit ascii encoding

### DIFF
--- a/sofar/io.py
+++ b/sofar/io.py
@@ -334,7 +334,7 @@ def _write_sofa(filename: str, sofa: sf.Sofa, compression=4, verify=True):
             if dtype == "f8":
                 tmp_var[:] = value
             else:
-                tmp_var[:] = stringtochar(value)
+                tmp_var[:] = stringtochar(value, encoding='utf-8')
 
             # write variable attributes
             sub_keys = [k for k in all_keys if k.startswith(f"{key}_")]

--- a/sofar/io.py
+++ b/sofar/io.py
@@ -335,7 +335,6 @@ def _write_sofa(filename: str, sofa: sf.Sofa, compression=4, verify=True):
                 tmp_var[:] = value
             else:
                 tmp_var[:] = stringtochar(value)
-                tmp_var._Encoding = "ascii"
 
             # write variable attributes
             sub_keys = [k for k in all_keys if k.startswith(f"{key}_")]


### PR DESCRIPTION
### Changes proposed in this pull request:

Remove the explicit ascii encoding for string variables when writing SOFA files. It is not required because the string data is read with ascii encoding when reading SOFA files (see `value = chartostring(value, encoding="ascii")` in sofar.io.py). In addition it is causing compatability issues with the Matlab SOFAToolbox, because it is writing `*__Encoding` variables that are ignored by the Python NETCDF API but not by the Matlab NETCDF API. The `*__Encoding` variables show up when reading SOFA files with Matlab and raise an error when trying to write such data with Matlab.

No new tests required. I did an additional manual check and could not find any differences in files written with and without explicit ascii encoding of string variables.