### PR TITLE
sofar: Restructure verification

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import sofar as sf
 
 
 # Temporary SOFA-file
-@pytest.fixture()
+@pytest.fixture
 def temp_sofa_file(tmp_path_factory):
     """
     Temporary small SOFA file.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import sofar as sf
 
 
 # Temporary SOFA-file
-@pytest.fixture
+@pytest.fixture()
 def temp_sofa_file(tmp_path_factory):
     """
     Temporary small SOFA file.

--- a/tests/test_sofa.py
+++ b/tests/test_sofa.py
@@ -351,3 +351,25 @@ def test___readonly():
     assert sf.Sofa._read_only("rm")
     assert not sf.Sofa._read_only("m")
     assert not sf.Sofa._read_only(None)
+
+
+@pytest.mark.parametrize(('sofa', 'deprecated'), [
+    # up to date convention
+    (sf.Sofa('SimpleHeadphoneIR'), False),
+    # convention with outdated version
+    (sf.Sofa('FreeFieldDirectivityTF', version='1.0', verify=False), True),
+    # deprecated convention
+    (sf.Sofa('GeneralFIRE', verify=False), True),
+])
+def test_deprecated(sofa, deprecated):
+
+    assert sofa.deprecated() == deprecated
+
+@pytest.mark.parametrize(('sofa', 'preliminary'), [
+    (sf.Sofa('SimpleHeadphoneIR', version='latest'), False),
+    # convention with outdated version
+    (sf.Sofa('AnnotatedEmitterAudio', version='0.2', verify=False), True),
+])
+def test_preliminary(sofa, preliminary):
+
+    assert sofa.preliminary() == preliminary

--- a/tests/test_sofa_verify.py
+++ b/tests/test_sofa_verify.py
@@ -463,18 +463,24 @@ def test_deprecations(file):
     # check warnings and errors
     sofa = sf.Sofa(deprecated, verify=False)
 
-    msg = ("Detected deprecations:\n"
-           f"- GLOBAL_SOFAConventions is {deprecated}, which is deprecated. ")
-
-    with pytest.warns(UserWarning, match=msg):
+    with pytest.warns(UserWarning, match="deprecated"):
         sofa.verify(mode="read")
 
-    with pytest.raises(ValueError, match=msg):
+    with pytest.raises(ValueError, match="deprecated"):
         sofa.verify(mode="write")
 
 
-def test_preliminary_conventions_version():
-    """Test if using a convention version < 1.0 issues a warning."""
+def test_deprecated_conventions():
+    """Test warning for deprecated convention."""
 
-    with pytest.warns(UserWarning, match="Detected preliminary"):
+    match = 'SingleRoomDRIR v0.3 is deprecated'
+    with pytest.warns(UserWarning, match=match):
         sf.Sofa("SingleRoomDRIR", version="0.3")
+
+
+def test_preliminary_convention():
+    """Test warning for preliminary convention."""
+
+    match = 'AnnotatedEmitterAudio v0.2 is preliminary'
+    with pytest.warns(UserWarning, match=match):
+        sf.Sofa("AnnotatedEmitterAudio", version="0.2")


### PR DESCRIPTION
### Changes proposed in this pull request:

- add class methods `deprecated` and `preliminary` to `Sofa` class. I hope this makes the state of SOFA conventions more clear and also the internal structure of the `Sofa.__init__` and `SOFA.verify`. This also prepares for a future update of the SOFA conventions which will render a few deprecated conventions invalid. They are hence already excluded here from the automatic verification if reading or creating a new SOFA file. They are of course still in place when writing a SOFA file.
- Add tests for new functionality
- Adapt tests for changed warning and error messages
