### PR TITLE
add packaging to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     'numpy>=1.14.0',
     'beautifulsoup4',
     'requests',
+    'packaging',
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #126

### Changes proposed in this pull request:

- It adds packaging to dependencies, which got lost when we switched to pyproject.toml.
- Apparently, it is installed by default with conda, so we did not notice it before.
- I checked for other missing packages, but found nothing