### PR TITLE
Fix AES69 reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ References
 ==========
 
 AES69-2022: *AES standard for file exchange - Spatial acoustic data file
-format*, Audio Engineering Society, Inc., New York, NY, USA.
-(https://www.aes.org/publications/standards/search.cfm?docID=99)
+format*, Audio Engineering Society, Inc., New York, NY, USA. Public SOFA and
+AES69 revision information is available at
+<https://www.sofaconventions.org/mediawiki/index.php/SOFA_(Spatially_Oriented_Format_for_Acoustics)>.
 
 P. Majdak, F. Zotter, F. Brinkmann, J. De Muynke, M. Mihocic, and M.
 Noisternig, "Spatially Oriented Format for Acoustics 2.1: Introduction and


### PR DESCRIPTION
Closes #139

### Changes proposed in this pull request:

- Replace the dead AES standards search URL in the README reference with the live SOFA conventions page.
- Keep the AES69-2022 bibliographic citation intact while pointing readers to public SOFA/AES69 revision information.

### Validation

- `git diff --check`
- `curl -L https://www.aes.org/publications/standards/search.cfm?docID=99` -> `404`
- `curl -L https://www.sofaconventions.org/mediawiki/index.php/SOFA_(Spatially_Oriented_Format_for_Acoustics)` -> `200`
- `UV_PROJECT_ENVIRONMENT=../.venv uv run --project .. --extra docs --extra tests python -m sphinx -b html . _build/html` from `docs/` -> passed
- `python -m sphinx -b linkcheck . _build/linkcheck` confirmed the new SOFA conventions URL as `ok`; the command exits nonzero because of pre-existing unrelated broken links in the docs (`verification_rules`, an old MIDI URL, and generated relative links).

### Duplicate check

Immediately before opening this PR, searches for `aes.org`, `docID=99`, `AES69 link`, `AES69 reference`, and `dead link` in `pyfar/sofar` PRs returned no matching open or closed PRs for this README reference fix.